### PR TITLE
Set a fixed tray icons size

### DIFF
--- a/panel/applets/tray/TrayApplet.vala
+++ b/panel/applets/tray/TrayApplet.vala
@@ -1,8 +1,8 @@
 /*
  * TrayApplet.vala
- * 
+ *
  * Copyright 2014 Ikey Doherty <ikey.doherty@gmail.com>
- * 
+ *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
@@ -21,22 +21,25 @@ public class TrayAppletImpl : Budgie.Applet
 {
     protected Na.Tray? tray;
     protected int icon_size = 22;
+    protected Gtk.Orientation orientation;
+    protected int padding;
 
     public TrayAppletImpl()
     {
         margin = 1;
+        padding = 0;
+        orientation = Gtk.Orientation.HORIZONTAL;
 
-        orientation_changed.connect((o)=> {
+        orientation_changed.connect((o) => {
+            orientation = o;
             tray.set_orientation(o);
         });
-        icon_size_changed.connect((i,s)=> {
-            if (tray != null) {
-                icon_size = (int)s;
-                tray.set_icon_size(icon_size);
-            }
+        icon_size_changed.connect((i, s) => {
+            icon_size = (int)i;
         });
+
         // When we get parented, go add the tray
-        notify.connect((o,p)=> {
+        notify.connect((o, p) => {
             if (p.name == "parent") {
                 integrate_tray();
             }
@@ -48,17 +51,45 @@ public class TrayAppletImpl : Budgie.Applet
 
     protected void integrate_tray()
     {
-        set_size_request(-1, -1);
-        tray = new Na.Tray.for_screen(get_screen(), Gtk.Orientation.HORIZONTAL);
-        tray.set_icon_size(icon_size);
+        tray = new Na.Tray.for_screen(get_screen(), orientation);
         tray.set_padding(5);
         add(tray);
         show_all();
     }
+
+    // WORKAROUND:
+    // Na.Tray always set allocation according with its own
+    // parent. Set a fixed size (according with icon_size)
+    // to have a better look.
+    protected override void size_allocate(Gtk.Allocation allocation)
+    {
+        int icon_size = (int) (this.icon_size * 0.75);
+        Gtk.Allocation tray_allocation = allocation;
+        if (orientation == Gtk.Orientation.HORIZONTAL) {
+            tray_allocation.height = icon_size;
+            padding = (allocation.height - icon_size) / 2 - allocation.y;
+        } else {
+            tray_allocation.width = icon_size;
+            padding = (allocation.width - icon_size) / 2 - allocation.x;
+        }
+        set_allocation(allocation);
+        tray.size_allocate(tray_allocation);
+    }
+    protected override bool draw(Cairo.Context cr)
+    {
+        if (orientation == Gtk.Orientation.HORIZONTAL) {
+            cr.translate(0, padding);
+        } else {
+            cr.translate(padding, 0);
+        }
+        return base.draw(cr);
+    }
+    // END WORKAROUND
+
 } // End class
 
 [ModuleInit]
-public void peas_register_types(TypeModule module) 
+public void peas_register_types(TypeModule module)
 {
     // boilerplate - all modules need this
     var objmodule = module as Peas.ObjectModule;


### PR DESCRIPTION
Na.Tray always set allocation according with its own
parent. Instead of resize Tray in that way, set a fixed
size (according with icon_size passed via panel multiplied
for 0.75) to have a better look.