### PR TITLE
More wm patches

### DIFF
--- a/wm/core.c
+++ b/wm/core.c
@@ -48,6 +48,9 @@ static void budgie_launch_rundialog(MetaDisplay *display,
                                      MetaKeyBinding *binding,
                                      gpointer user_data);
 
+static void kill_window_effects(MetaPlugin *plugin,
+                                MetaWindowActor *actor);
+
 static const MetaPluginInfo *budgie_plugin_info(MetaPlugin *plugin);
 
 static void budgie_wm_class_init(BudgieWMClass *klass)
@@ -66,11 +69,11 @@ static void budgie_wm_class_init(BudgieWMClass *klass)
         plugin_class->plugin_info      = budgie_plugin_info;
         plugin_class->switch_workspace = switch_workspace;
         plugin_class->kill_switch_workspace = kill_switch_workspace;
+        plugin_class->kill_window_effects = kill_window_effects;
 
         /* Existing legacy code from old default plugin */
         plugin_class->show_tile_preview = show_tile_preview;
         plugin_class->hide_tile_preview = hide_tile_preview;
-        plugin_class->kill_window_effects   = kill_window_effects;
         plugin_class->confirm_display_change = confirm_display_change;
 }
 
@@ -189,6 +192,13 @@ static void budgie_launch_rundialog(MetaDisplay *display,
         /* Run the budgie-run-dialog
         * TODO: Make this path customisable */
         g_spawn_command_line_async("budgie-run-dialog", NULL);
+}
+
+static void kill_window_effects(MetaPlugin *plugin,
+                                MetaWindowActor *actor)
+{
+        g_signal_emit_by_name(actor, "transitions-completed",
+                              actor, plugin, NULL);
 }
 
 static const MetaPluginInfo *budgie_plugin_info(MetaPlugin *plugin)

--- a/wm/legacy.c
+++ b/wm/legacy.c
@@ -190,33 +190,6 @@ hide_tile_preview (MetaPlugin *plugin)
   clutter_actor_hide (preview->actor);
 }
 
-void
-kill_window_effects (MetaPlugin      *plugin,
-                     MetaWindowActor *window_actor)
-{
-  ActorPrivate *apriv;
-
-  apriv = get_actor_private (window_actor);
-
-  if (apriv->tml_minimize)
-    {
-      clutter_timeline_stop (apriv->tml_minimize);
-      g_signal_emit_by_name (apriv->tml_minimize, "completed", NULL);
-    }
-
-  if (apriv->tml_map)
-    {
-      clutter_timeline_stop (apriv->tml_map);
-      g_signal_emit_by_name (apriv->tml_map, "completed", NULL);
-    }
-
-  if (apriv->tml_destroy)
-    {
-      clutter_timeline_stop (apriv->tml_destroy);
-      g_signal_emit_by_name (apriv->tml_destroy, "completed", NULL);
-    }
-}
-
 static void
 on_dialog_closed (GPid     pid,
                   gint     status,

--- a/wm/legacy.c
+++ b/wm/legacy.c
@@ -19,43 +19,22 @@
  * along with this program; if not, see <http://www.gnu.org/licenses/>.
  */
 
-#pragma GCC diagnostic ignored "-Wdeprecated"
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-/* Because GCC is tripping about the bitfields */
-#pragma GCC diagnostic ignored "-Woverflow"
 
 #include <config.h>
 
 #include <meta/meta-plugin.h>
-#include <meta/window.h>
 #include <meta/meta-background-group.h>
-#include <meta/meta-background-actor.h>
-#include <meta/prefs.h>
-#include <meta/keybindings.h>
 #include <meta/util.h>
-#include <glib/gi18n-lib.h>
-#include <meta/meta-version.h>
 
 #include <clutter/clutter.h>
-#include <gmodule.h>
-#include <string.h>
-
-#include <gio/gdesktopappinfo.h>
-
-#define MAXIMIZE_TIMEOUT   100
-#define BACKGROUND_TIMEOUT 250
-#define SWITCH_TIMEOUT    1
 
 #include "plugin.h"
-#include "impl.h"
 #include "background.h"
 
-#define ACTOR_DATA_KEY "MCCP-Default-actor-data"
 #define SCREEN_TILE_PREVIEW_DATA_KEY "MCCP-Default-screen-tile-preview-data"
 
-static GQuark actor_data_quark = 0;
 static GQuark screen_tile_preview_data_quark = 0;
-
 
 typedef struct _ScreenTilePreview
 {
@@ -65,36 +44,6 @@ typedef struct _ScreenTilePreview
 
   MetaRectangle   tile_rect;
 } ScreenTilePreview;
-
-/*
- * Actor private data accessor
- */
-static void
-free_actor_private (gpointer data)
-{
-  if (G_LIKELY (data != NULL))
-    g_slice_free (ActorPrivate, data);
-}
-
-ActorPrivate *
-get_actor_private (MetaWindowActor *actor)
-{
-  ActorPrivate *priv = g_object_get_qdata (G_OBJECT (actor), actor_data_quark);
-
-  if (G_UNLIKELY (actor_data_quark == 0))
-    actor_data_quark = g_quark_from_static_string (ACTOR_DATA_KEY);
-
-  if (G_UNLIKELY (!priv))
-    {
-      priv = g_slice_new0 (ActorPrivate);
-
-      g_object_set_qdata_full (G_OBJECT (actor),
-                               actor_data_quark, priv,
-                               free_actor_private);
-    }
-
-  return priv;
-}
 
 void
 on_monitors_changed (MetaScreen *screen,

--- a/wm/legacy.h
+++ b/wm/legacy.h
@@ -27,10 +27,6 @@
 typedef struct _ActorPrivate
 {
   ClutterActor *orig_parent;
-
-  ClutterTimeline *tml_minimize;
-  ClutterTimeline *tml_destroy;
-  ClutterTimeline *tml_map;
 } ActorPrivate;
 
 /* callback data for when animations complete */
@@ -46,9 +42,6 @@ ActorPrivate *get_actor_private (MetaWindowActor *actor);
 void
 on_monitors_changed (MetaScreen *screen,
                      MetaPlugin *plugin);
-
-void kill_window_effects   (MetaPlugin      *plugin,
-                                   MetaWindowActor *actor);
 
 void show_tile_preview (MetaPlugin      *plugin,
                                MetaWindow      *window,

--- a/wm/legacy.h
+++ b/wm/legacy.h
@@ -21,32 +21,14 @@
 
 #pragma once
 
-/*
- * Per actor private data we attach to each actor.
- */
-typedef struct _ActorPrivate
-{
-  ClutterActor *orig_parent;
-} ActorPrivate;
-
-/* callback data for when animations complete */
-typedef struct
-{
-  ClutterActor *actor;
-  MetaPlugin *plugin;
-} EffectCompleteData;
-
-
-ActorPrivate *get_actor_private (MetaWindowActor *actor);
-
-void
-on_monitors_changed (MetaScreen *screen,
-                     MetaPlugin *plugin);
+void on_monitors_changed (MetaScreen *screen,
+                          MetaPlugin *plugin);
 
 void show_tile_preview (MetaPlugin      *plugin,
-                               MetaWindow      *window,
-                               MetaRectangle   *tile_rect,
-                               int              tile_monitor_number);
+                        MetaWindow      *window,
+                        MetaRectangle   *tile_rect,
+                        int              tile_monitor_number);
+
 void hide_tile_preview (MetaPlugin      *plugin);
 
 void confirm_display_change (MetaPlugin *plugin);


### PR DESCRIPTION
Commit messages say it all, really. Just more removal of old stuff from legacy. Only code that is left there now is related to tile previews, dialogs and the on_monitors_changed callback. Is there a reason the latter one is still in legacy?