### PR TITLE
Apply inbuilt theme setting on startup

### DIFF
--- a/panel/manager.vala
+++ b/panel/manager.vala
@@ -275,7 +275,7 @@ public class PanelManager : DesktopManager
             return;
         }
         if (settings.get_boolean(key)) {
-            this.current_theme_uri = "resource://com/solus-project/budgie/theme.css";
+            this.current_theme_uri = "resource://com/solus-project/budgie/theme/theme.css";
         } else {
             this.current_theme_uri = null;
         }
@@ -304,10 +304,10 @@ public class PanelManager : DesktopManager
         raven = new Budgie.Raven(this);
 
         this.on_monitors_changed();
-        this.current_theme_uri = "resource://com/solus-project/budgie/theme/theme.css";
 
         gtksettings.notify["gtk-theme-name"].connect(on_theme_changed);
-        on_theme_changed();
+
+        on_settings_changed("builtin-theme");
 
         /* Some applets might want raven */
         raven.setup_dbus();


### PR DESCRIPTION
Budgie doesn't check the "builtin-theme" setting on startup.
So, if you disable the inbuilt theme and restart budgie with `budgie-panel --replace &` it will use the inbuilt theme regardless of the setting and you have to click the switch two times to disable the inbuilt theme again.
At this point you can't re-enable the inbuilt theme because of a [wrong uri](https://github.com/solus-project/budgie-desktop/blob/master/panel/manager.vala#L278) (I fixed that too, ofc).

So instead of setting the builtin theme on startup, first check the setting and set it if "builtin-theme" is true with the `on_settings_changed()` method instead of just calling `on_theme_changed()`

Edit: I think https://github.com/solus-project/budgie-desktop/issues/304 refers to this issue aswell.