### PR TITLE
Consistent Raven Toggle behavior and unread string.

### DIFF
--- a/panel/applets/notifications/NotificationsApplet.vala
+++ b/panel/applets/notifications/NotificationsApplet.vala
@@ -24,7 +24,6 @@ public static const string RAVEN_DBUS_OBJECT_PATH = "/com/solus_project/budgie/R
 public interface RavenRemote : Object
 {
     public abstract async void Toggle() throws Error;
-    public abstract async void ToggleNotification() throws Error;
     public signal void NotificationsChanged();
     public abstract async uint GetNotificationCount() throws Error;
     public signal void UnreadNotifications();
@@ -33,7 +32,6 @@ public interface RavenRemote : Object
 
 public class NotificationsApplet : Budgie.Applet
 {
-    bool show_notification_view = false;  // Show Applet View by default (show_notification_view false)
     Gtk.EventBox? widget;
     Gtk.Image? icon;
     RavenRemote? raven_proxy = null;
@@ -55,13 +53,11 @@ public class NotificationsApplet : Budgie.Applet
     void on_notifications_read()
     {
         this.icon.get_style_context().remove_class("alert");
-        this.show_notification_view = false; // No longer default to showing notification view
     }
 
     void on_notifications_unread()
     {
         this.icon.get_style_context().add_class("alert");
-        this.show_notification_view = true; // Default to showing notification view
     }
 
     void on_get_count(GLib.Object? o, AsyncResult? res)
@@ -99,11 +95,7 @@ public class NotificationsApplet : Budgie.Applet
             return Gdk.EVENT_PROPAGATE;
         }
         try {
-            if (!this.show_notification_view) {
-                raven_proxy.Toggle();
-            } else {
-                raven_proxy.ToggleNotification();
-            }
+            raven_proxy.Toggle();
         } catch (Error e) {
             message("Failed to toggle Raven: %s", e.message);
         }

--- a/raven/notifications_view.vala
+++ b/raven/notifications_view.vala
@@ -445,12 +445,13 @@ public class NotificationsView : Gtk.Box
 
         string? text = null;
         if (len > 1) {
-            text = _("%u new notifications".printf(len));
+            text = _("%u unread notifications").printf(len);
         } else if (len == 1) {
-            text = _("1 new notification");
+            text = _("1 unread notification");
         } else {
-            text = _("No new notifications");
-        }
+            text = _("No unread notifications");
+        }    
+
         Raven.get_instance().set_notification_count(len);
         header.text = text;
     }

--- a/raven/raven.vala
+++ b/raven/raven.vala
@@ -42,20 +42,16 @@ public class RavenIface
         this.is_expanded = b;
     }
 
-    public void Toggle()
-    {
+    public void Toggle() {
         this.is_expanded = !this.is_expanded;
-        if (this.is_expanded) {
-            parent.expose_main_view();
-        }
-    }
 
-    public void ToggleNotification()
-    {
-        this.is_expanded = !this.is_expanded;
         if (this.is_expanded) {
-            parent.expose_notification();
-            this.ReadNotifications();
+            if (this.notifications == 0){
+                parent.expose_main_view();
+            } else {
+                parent.expose_notification();
+                this.ReadNotifications();
+            }
         }
     }
 


### PR DESCRIPTION
This commit ensures that both the NotificationsApplet and keyboard shortcut have the same Raven toggling behavior, which is to show the Notification view by default if there are unread notifications. Also fixes unread string differences.

**Note:** Not sure if the "new" v.s. "unread" terminology difference between the NotificationApplet and Notification View was intentional. Would like to know if it was or if the difference was just a derp :stuck_out_tongue: 