### PR TITLE
Introduce more popovers and stop right-click nonsense.

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -22,12 +22,12 @@ us!!
  * [ ] Add pinning capabilities to the Budgie Menu itself
  * [x] Disallow Ugly Apps from overriding the icon (main chrome instance, hexchat, etc)
  * [ ] Turn Power Icon into a user menu (Hibernate, Switch User, etc)
- * [ ] Ensure all popover-associated applets use this as  the *primary* action, no
+ * [x] Ensure all popover-associated applets use this as  the *primary* action, no
        more right-click left-click nonsense. Left click only.
  * [ ] Just because it's at the end of the panel, doesn't mean it needs to launch
        feckin Raven. Notification icon + sound are sufficient.
  * [ ] Add intellihide.
- * [ ] More popovers.
+ * [x] More popovers.
  * [x] Add workaround for clicking on the desktop to allow dismissing of Raven
        for when Nautilus isn't being used..
 

--- a/panel/applets/clock/ClockApplet.vala
+++ b/panel/applets/clock/ClockApplet.vala
@@ -1,8 +1,8 @@
 /*
  * This file is part of budgie-desktop
- * 
+ *
  * Copyright (C) 2014-2016 Ikey Doherty <ikey@solus-project.com>
- * 
+ *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
@@ -51,7 +51,6 @@ public class ClockApplet : Budgie.Applet
         time = new DateTime.now_local();
         widget.add(clock);
 
-
         var menu = new GLib.Menu();
         menu.append(_("Time and date settings"), "clock.time_and_date");
         menu.append(_("Calendar"), "clock.calendar");
@@ -60,7 +59,7 @@ public class ClockApplet : Budgie.Applet
         popover.get_child().show_all();
 
         widget.button_press_event.connect((e)=> {
-            if (e.button != 3) {
+            if (e.button != 1) {
                 return Gdk.EVENT_PROPAGATE;
             }
             if (popover.get_visible()) {

--- a/panel/applets/status/BluetoothIndicator.vala
+++ b/panel/applets/status/BluetoothIndicator.vala
@@ -1,6 +1,6 @@
 /*
  * This file is part of budgie-desktop
- * 
+ *
  * Copyright (C) 2015-2016 Ikey Doherty <ikey@solus-project.com>
  * Copyright (C) 2015 Alberts Muktupāvels
  *
@@ -76,7 +76,7 @@ public class BluetoothIndicator : Gtk.Bin
         if (!model.iter_children(out iter, adapter)) {
             return 0;
         }
-        
+
         while (true) {
             bool con;
             model.get(iter, Bluetooth.Column.CONNECTED, out con, -1);
@@ -136,14 +136,19 @@ public class BluetoothIndicator : Gtk.Bin
 
     void on_send_file()
     {
-        var app_info = AppInfo.create_from_commandline("bluetooth-sendto", "Bluetooth Transfer", AppInfoCreateFlags.NONE);
-        if (app_info == null) {
-            return;
-        }
         try {
-            app_info.launch(null, null);
+            var app_info = AppInfo.create_from_commandline("bluetooth-sendto", "Bluetooth Transfer", AppInfoCreateFlags.NONE);
+            if (app_info == null) {
+                return;
+            }
+
+            try {
+                app_info.launch(null, null);
+            } catch (Error e) {
+                message("Unable to launch bluetooth-sendto: %s", e.message);
+            }
         } catch (Error e) {
-            message("Unable to launch bluetooth-sendto: %s", e.message);
+            message("Unable to create bluetooth-sendto AppInfo: %s", e.message);
         }
     }
 

--- a/panel/applets/status/PowerIndicator.vala
+++ b/panel/applets/status/PowerIndicator.vala
@@ -1,6 +1,6 @@
 /*
  * This file is part of budgie-desktop
- * 
+ *
  * Copyright (C) 2015-2016 Ikey Doherty <ikey@solus-project.com>
  *
  * This program is free software; you can redistribute it and/or modify
@@ -69,7 +69,9 @@ public class PowerIndicator : Gtk.Bin
 {
 
     /** Widget containing battery icons to display */
-    public Gtk.Box widget { protected set; public get; }
+    public Gtk.EventBox? ebox = null;
+    public Gtk.Popover? popover = null;
+    private Gtk.Box widget = null;
 
     /** Our upower client */
     public Up.Client client { protected set; public get; }
@@ -79,10 +81,23 @@ public class PowerIndicator : Gtk.Bin
     public PowerIndicator()
     {
         devices = new HashTable<string,BatteryIcon?>(str_hash, str_equal);
+        ebox = new Gtk.EventBox();
+        add(ebox);
 
         widget = new Gtk.Box(Gtk.Orientation.HORIZONTAL, 2);
-        add(widget);
+        ebox.add(widget);
 
+        var menu = new GLib.Menu();
+        menu.append(_("Power settings"), "power.settings");
+
+        popover = new Gtk.Popover.from_model(ebox, menu);
+
+        var group = new GLib.SimpleActionGroup();
+        var power = new GLib.SimpleAction("settings", null);
+        power.activate.connect(open_power_settings);
+        group.add_action(power);
+
+        this.insert_action_group("power", group);
         client = new Up.Client();
 
         this.sync_devices();
@@ -98,6 +113,19 @@ public class PowerIndicator : Gtk.Bin
             return false;
         }
         return true;
+    }
+
+    void open_power_settings() {
+        var app_info = new DesktopAppInfo("gnome-power-panel.desktop");
+        if (app_info == null) {
+            return;
+        }
+
+        try {
+            app_info.launch(null, null);
+        } catch (Error e) {
+            message("Unable to launch gnome-power-panel.desktop: %s", e.message);
+        }
     }
 
     /**

--- a/panel/applets/status/StatusApplet.vala
+++ b/panel/applets/status/StatusApplet.vala
@@ -1,8 +1,8 @@
 /*
  * This file is part of budgie-desktop
- * 
+ *
  * Copyright (C) 2015-2016 Ikey Doherty <ikey@solus-project.com>
- * 
+ *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
@@ -53,13 +53,17 @@ public class StatusApplet : Budgie.Applet
         blue = new BluetoothIndicator();
         widget.pack_start(blue, false, false, 2);
 
-        wrap.button_release_event.connect(on_button_release);
+        sound.button_release_event.connect(on_button_release);
 
-        var power = new Gtk.Image.from_icon_name("system-shutdown-symbolic", Gtk.IconSize.MENU);
-        widget.pack_start(power, false, false, 2);
+        var power_image_wrap = new Gtk.EventBox();
+        widget.pack_start(power_image_wrap, false, false, 2);
+
+        var power_image = new Gtk.Image.from_icon_name("system-shutdown-symbolic", Gtk.IconSize.MENU);
+        power_image_wrap.add(power_image);
+        power_image_wrap.button_release_event.connect(on_button_release);
 
         blue.ebox.button_press_event.connect((e)=> {
-            if (e.button != 3) {
+            if (e.button != 1) {
                 return Gdk.EVENT_PROPAGATE;
             }
             if (blue.popover.get_visible()) {
@@ -70,14 +74,26 @@ public class StatusApplet : Budgie.Applet
             return Gdk.EVENT_STOP;
         });
 
+        power.ebox.button_press_event.connect((e)=> {
+            if (e.button != 1) {
+                return Gdk.EVENT_PROPAGATE;
+            }
+            if (power.popover.get_visible()) {
+                power.popover.hide();
+            } else {
+                this.manager.show_popover(power.ebox);
+            }
+            return Gdk.EVENT_STOP;
+        });
+
         show_all();
 
         setup_dbus();
     }
 
-    bool on_button_release(Gdk.EventButton? button)
+    bool on_button_release(Gdk.EventButton? e)
     {
-        if (button.button != 1) {
+        if (e.button != 1) {
             return Gdk.EVENT_PROPAGATE;
         }
         try {
@@ -92,6 +108,7 @@ public class StatusApplet : Budgie.Applet
     {
         this.manager = manager;
         manager.register_popover(blue.ebox, blue.popover);
+        manager.register_popover(power.ebox, power.popover);
     }
 
     /* Hold onto our Raven proxy ref */
@@ -117,7 +134,7 @@ public class StatusApplet : Budgie.Applet
 } // End class
 
 [ModuleInit]
-public void peas_register_types(TypeModule module) 
+public void peas_register_types(TypeModule module)
 {
     // boilerplate - all modules need this
     var objmodule = module as Peas.ObjectModule;


### PR DESCRIPTION
**Summary of commit:**
- Implemented popover for PowerIndicator that has a "Power Settings" option. Opens up gnome-power-panel.desktop
- Changed right-click actions to left-click.
 - Wrapped power icon in an EventBox as a result (so we can feed it on_button_release). This'll *hopefully* be changed later via UserIndicator, but for now let's just make it trigger Raven.
- Added try / catch for bluetooth send-to. It has the possibility of providing a `GLib.Error`, thus should be handled appropriately.
 - Shuts up Vala's warning about it too, so that's nice.
- I like tick boxes. Let's add them to the TODO :smile:

**What might need testing:**
- Make sure no bork happened for the Bluetooth applet please. I don't have integrated Bluetooth on this system so honestly I have no idea. In all likelihood it is fine, but ya know, couldn't hurt to check right?