### PR TITLE
Implemented workaround for dismissing Raven on desktop click.

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -28,7 +28,7 @@ us!!
        feckin Raven. Notification icon + sound are sufficient.
  * [ ] Add intellihide.
  * [ ] More popovers.
- * [ ] Add workaround for clicking on the desktop to allow dismissing of Raven
+ * [x] Add workaround for clicking on the desktop to allow dismissing of Raven
        for when Nautilus isn't being used..
 
 **Icon Tasklist**
@@ -37,7 +37,7 @@ us!!
  * [ ] Switch to a GtkFlowBox for better sorting
 
  ![Popovers Everywhere](http://cdn.meme.am/instances/500x/63501402.jpg)
- 
+
 **Raven**
 
  * [ ] Add proper Raven API for applets (single instance, unlike Budgie Panel)

--- a/raven/raven.vala
+++ b/raven/raven.vala
@@ -1,8 +1,8 @@
 /*
  * This file is part of budgie-desktop
- * 
+ *
  * Copyright (C) 2015-2016 Ikey Doherty <ikey@solus-project.com>
- * 
+ *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
@@ -36,6 +36,10 @@ public class RavenIface
         public get {
             return parent.get_expanded();
         }
+    }
+
+    public bool GetExpanded() {
+        return this.is_expanded;
     }
 
     public void SetExpanded(bool b) {

--- a/wm/wm.vala
+++ b/wm/wm.vala
@@ -60,6 +60,7 @@ public class ScreenTilePreview : Clutter.Actor
 [DBus (name="com.solus_project.budgie.Raven")]
 public interface RavenRemote : Object
 {
+    public abstract bool GetExpanded() throws Error;
     public abstract async void Toggle() throws Error;
 }
 
@@ -392,14 +393,21 @@ public class BudgieWM : Meta.Plugin
 
     bool on_button_release(Clutter.ButtonEvent? event)
     {
-        if (event.button != 3) {
+
+        if (event.button == 1) {
+            if ((raven_proxy != null) && raven_proxy.GetExpanded()) { // If is expanded
+                raven_proxy.Toggle(); // Close
+            }
+        } else if (event.button == 3 ) {
+            if (menu.get_visible()) {
+                menu.hide();
+            } else {
+                menu.popup(null, null, null, event.button, event.time);
+            }
+        } else {
             return CLUTTER_EVENT_PROPAGATE;
         }
-        if (menu.get_visible()) {
-            menu.hide();
-        } else {
-            menu.popup(null, null, null, event.button, event.time);
-        }
+
         return CLUTTER_EVENT_STOP;
     }
 


### PR DESCRIPTION
As a result, new func GetExpanded implemented for Raven, and on_button_release expanded to support left-click, in addition to existing right-click for menu.