### PR TITLE
raven: Update the calendar widget so ikey doesn't miss his rent

### DIFF
--- a/raven/calendar.vala
+++ b/raven/calendar.vala
@@ -40,6 +40,7 @@ public class CalendarWidget : Gtk.Box
         var time = new DateTime.now_local();
         var strf = time.format(date_format);
         header.text = strf;
+        cal.day = int.parse(time.format("%e"));
         return true;
     }
 

--- a/raven/calendar.vala
+++ b/raven/calendar.vala
@@ -40,7 +40,7 @@ public class CalendarWidget : Gtk.Box
         var time = new DateTime.now_local();
         var strf = time.format(date_format);
         header.text = strf;
-        cal.day = int.parse(time.format("%e"));
+        cal.day = time.get_day_of_month();
         return true;
     }
 


### PR DESCRIPTION
Currently the selected day stays fixed on the day budgie-panel was started.