### PR TITLE
raven: Fix NotificationClone icon size

### DIFF
--- a/raven/notifications_view.vala
+++ b/raven/notifications_view.vala
@@ -71,12 +71,12 @@ public class NotificationClone : Gtk.Grid
     public NotificationClone(NotificationWindow? target)
     {
         if (target.pixbuf != null) {
-            this.image_icon.set_from_pixbuf(target.pixbuf);
+            Gdk.Pixbuf scaled_pixbuf = target.pixbuf.scale_simple(32, 32, Gdk.InterpType.NEAREST);
+            this.image_icon.set_from_pixbuf(scaled_pixbuf);
         } else {
             this.image_icon.set_from_icon_name(target.icon_name, Gtk.IconSize.INVALID);
+            this.image_icon.pixel_size = 32;
         }
-
-        this.image_icon.pixel_size = 32;
 
         label_title.set_markup(target.title);
         label_body.set_markup(target.body);
@@ -218,7 +218,7 @@ public class NotificationWindow : Gtk.Window
         try {
             var file = File.new_for_path(image_path);
             var ins = yield file.read_async(Priority.DEFAULT, null);
-            Gdk.Pixbuf? pbuf = yield new Gdk.Pixbuf.from_stream_at_scale_async(ins, 32, 32, true, cancel);
+            Gdk.Pixbuf? pbuf = yield new Gdk.Pixbuf.from_stream_at_scale_async(ins, 48, 48, true, cancel);
             this.pixbuf = pbuf;
             image_icon.set_from_pixbuf(pbuf);
         } catch (Error e) {

--- a/raven/notifications_view.vala
+++ b/raven/notifications_view.vala
@@ -74,8 +74,9 @@ public class NotificationClone : Gtk.Grid
             this.image_icon.set_from_pixbuf(target.pixbuf);
         } else {
             this.image_icon.set_from_icon_name(target.icon_name, Gtk.IconSize.INVALID);
-            this.image_icon.pixel_size = 32;
         }
+
+        this.image_icon.pixel_size = 32;
 
         label_title.set_markup(target.title);
         label_body.set_markup(target.body);

--- a/raven/notifications_view.vala
+++ b/raven/notifications_view.vala
@@ -214,11 +214,11 @@ public class NotificationWindow : Gtk.Window
         }
 
         this.image_path = img_path;
-    
+
         try {
             var file = File.new_for_path(image_path);
             var ins = yield file.read_async(Priority.DEFAULT, null);
-            Gdk.Pixbuf? pbuf = yield new Gdk.Pixbuf.from_stream_at_scale_async(ins, 48, 48, true, cancel);
+            Gdk.Pixbuf? pbuf = yield new Gdk.Pixbuf.from_stream_at_scale_async(ins, 32, 32, true, cancel);
             this.pixbuf = pbuf;
             image_icon.set_from_pixbuf(pbuf);
         } catch (Error e) {

--- a/raven/ui/notification_clone.ui
+++ b/raven/ui/notification_clone.ui
@@ -13,7 +13,7 @@
         <property name="margin_left">8</property>
         <property name="margin_right">8</property>
         <property name="margin_top">8</property>
-        <property name="pixel_size">48</property>
+        <property name="pixel_size">32</property>
         <property name="icon_name">mail-unread-symbolic</property>
         <property name="icon_size">6</property>
       </object>


### PR DESCRIPTION
Change `pixel_size` in `notification_clone.ui` to `32`
Create a copy of the `NotificationWindow` icon pixbuf scaled at **32x32** and use that for `NotificationClone`

tl;dr: Same icon size for all notification clones.

**Before**&nbsp;&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;**After**
![screenshot from 2016-07-13 21-38-43](https://cloud.githubusercontent.com/assets/3101505/16817439/089282e6-4943-11e6-99d0-4e1c8d29a063.png)
