### PR TITLE
raven: add some margin to the NotificationClone timestamp label

### DIFF
--- a/raven/notifications_view.vala
+++ b/raven/notifications_view.vala
@@ -82,6 +82,7 @@ public class NotificationClone : Gtk.Grid
 
         var date = new DateTime.from_unix_local(target.timestamp);
         label_timestamp.set_text(date.format("%H:%M"));
+        label_timestamp.margin_start = 5;
     }
 }
 

--- a/raven/notifications_view.vala
+++ b/raven/notifications_view.vala
@@ -82,7 +82,6 @@ public class NotificationClone : Gtk.Grid
 
         var date = new DateTime.from_unix_local(target.timestamp);
         label_timestamp.set_text(date.format("%H:%M"));
-        label_timestamp.margin_start = 5;
     }
 }
 

--- a/raven/ui/notification_clone.ui
+++ b/raven/ui/notification_clone.ui
@@ -72,7 +72,8 @@
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="halign">end</property>
-        <property name="margin_right">4</property>
+        <property name="margin_start">4</property>
+        <property name="margin_end">4</property>
         <property name="label">label</property>
         <style>
           <class name="dim-label"/>


### PR DESCRIPTION
**Before**&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**After**
![screenshot from 2016-07-13 21-38-43](https://cloud.githubusercontent.com/assets/3101505/16817976/a87afd36-4945-11e6-9a8f-ffae39a0db40.png)
