### PR TITLE
PanelEditor: Fix separator height with GTK 3.20

### DIFF
--- a/raven/settings_view.vala
+++ b/raven/settings_view.vala
@@ -625,6 +625,7 @@ public class PanelEditor : Gtk.Box
             label.get_style_context().add_class("dim-label");
             label.halign = Gtk.Align.START;
             var sep = new Gtk.Separator(Gtk.Orientation.HORIZONTAL);
+            sep.set_valign(Gtk.Align.CENTER);
             label.margin_start = 8;
             label.margin_end = 6;
             label.margin_top = 3;


### PR DESCRIPTION
This fixes the separator height in the panel editor with GTK 3.20.

Comparison:
![before](https://cloud.githubusercontent.com/assets/8473629/17479977/f11056ba-5d75-11e6-9dd5-2a10f75b7f8e.png) ![after](https://cloud.githubusercontent.com/assets/8473629/17479978/f2df273c-5d75-11e6-8a54-26a3e609ec11.png)

