### PR TITLE
Raven Trigger: use standard icons

### DIFF
--- a/panel/applets/raven-trigger/RavenTriggerApplet.plugin.in
+++ b/panel/applets/raven-trigger/RavenTriggerApplet.plugin.in
@@ -5,4 +5,4 @@ _Description=Raven Sidebar Control
 Authors=Ikey Doherty
 Copyright=Copyright © 2016 Ikey Doherty
 Website=https://solus-project.com
-Icon=pane-show-symbolic
+Icon=go-previous-symbolic

--- a/panel/applets/raven-trigger/RavenTriggerApplet.vala
+++ b/panel/applets/raven-trigger/RavenTriggerApplet.vala
@@ -46,8 +46,8 @@ public class RavenTriggerApplet : Budgie.Applet
         widget.set_can_focus(false);
         widget.get_style_context().add_class("raven-trigger");
 
-        img_hidden = new Gtk.Image.from_icon_name("pane-show-symbolic", Gtk.IconSize.BUTTON);
-        img_expanded = new Gtk.Image.from_icon_name("pane-hide-symbolic", Gtk.IconSize.BUTTON);
+        img_hidden = new Gtk.Image.from_icon_name("go-previous-symbolic", Gtk.IconSize.BUTTON);
+        img_expanded = new Gtk.Image.from_icon_name("go-next-symbolic", Gtk.IconSize.BUTTON);
 
         img_stack = new Gtk.Stack();
         img_stack.add_named(img_hidden, "hidden");


### PR DESCRIPTION
pane-show and pane-hide are non-standard icons, they are missing from the Adwaita icon theme. Use go-previous and go-next instead.

Alternatively, add the pane-show-symbolic pane-hide-symbolic icons to the budgie-desktop project to provide fallback icons.