### PR TITLE
Implemented Hibernate option in User Indicator

### DIFF
--- a/panel/applets/user-indicator/DBusInterfaces.vala
+++ b/panel/applets/user-indicator/DBusInterfaces.vala
@@ -29,6 +29,7 @@ interface PropertiesInterface : Object {
 [DBus (name = "org.freedesktop.login1.Manager")]
 public interface LogindInterface : Object {
     public abstract void suspend(bool interactive) throws IOError;
+    public abstract void hibernate(bool interactive) throws IOError;
 }
 
 [DBus (name="org.gnome.SessionManager")]

--- a/panel/applets/user-indicator/UserIndicatorWindow.vala
+++ b/panel/applets/user-indicator/UserIndicatorWindow.vala
@@ -100,6 +100,7 @@ public class UserIndicatorWindow : Gtk.Popover {
 
         IndicatorItem lock_menu = new IndicatorItem(_("Lock"), "system-lock-screen-symbolic", false);
         IndicatorItem suspend_menu = new IndicatorItem(_("Suspend"), "media-playback-pause-symbolic", false);
+        IndicatorItem hibernate_menu = new IndicatorItem(_("Hibernate"), "system-suspend-hibernate", false);
         IndicatorItem reboot_menu = new IndicatorItem(_("Restart"), "media-playlist-repeat-symbolic", false);
         IndicatorItem shutdown_menu = new IndicatorItem(_("Shutdown"), "system-shutdown-symbolic", false);
 
@@ -109,6 +110,7 @@ public class UserIndicatorWindow : Gtk.Popover {
         items.add(separator);
         items.add(lock_menu);
         items.add(suspend_menu);
+        items.add(hibernate_menu);
         items.add(reboot_menu);
         items.add(shutdown_menu);
 
@@ -135,6 +137,14 @@ public class UserIndicatorWindow : Gtk.Popover {
             return Gdk.EVENT_STOP;
         });
 
+        suspend_menu.button_release_event.connect((e) => {
+            if (e.button != 1) {
+                return Gdk.EVENT_PROPAGATE;
+            }
+            suspend();
+            return Gdk.EVENT_STOP;
+        });
+
         reboot_menu.button_release_event.connect((e) => {
             if (e.button != 1) {
                 return Gdk.EVENT_PROPAGATE;
@@ -143,19 +153,19 @@ public class UserIndicatorWindow : Gtk.Popover {
             return Gdk.EVENT_STOP;
         });
 
+        hibernate_menu.button_release_event.connect((e) => {
+            if (e.button != 1) {
+                return Gdk.EVENT_PROPAGATE;
+            }
+            hibernate();
+            return Gdk.EVENT_STOP;
+        });
+
         shutdown_menu.button_release_event.connect((e) => {
             if (e.button != 1) {
                 return Gdk.EVENT_PROPAGATE;
             }
             shutdown();
-            return Gdk.EVENT_STOP;
-        });
-
-        suspend_menu.button_release_event.connect((e) => {
-            if (e.button != 1) {
-                return Gdk.EVENT_PROPAGATE;
-            }
-            suspend();
             return Gdk.EVENT_STOP;
         });
 
@@ -258,6 +268,19 @@ public class UserIndicatorWindow : Gtk.Popover {
             session.Logout(0);
         } catch (Error e) {
             warning("Failed to logout: %s", e.message);
+        }
+    }
+
+    private void hibernate() {
+        if (logind_interface == null) {
+            return;
+        }
+
+        try {
+            lock_screen();
+            logind_interface.hibernate(false);
+        } catch (Error e) {
+            warning("Cannot hibernate: %s", e.message);
         }
     }
 


### PR DESCRIPTION
Implemented Hibernate option in User Indicator, which leverages the Hibernate functionality exposed in logind.

Notes:
- Didn't actually work on my system, but could be an issue with my fstab, Solus, whatever it may been. Thus testing requested.
- No prompt is provided upon clicking. It's just mainly "prepare your butt" then it hibernates..ish.
- Suspend menu item binding moved because I was getting anal about the fact that the ordering of menu items being added and the listening events being added weren't the same.