### PR TITLE
Fix theme for GTK+ 3.22

### DIFF
--- a/theme/3.20/sass/_main.scss
+++ b/theme/3.20/sass/_main.scss
@@ -274,7 +274,7 @@ popover row {
 
     // Switches
     switch {
-        font: 1;
+        font-size: 1px;
         outline-color: transparent;
 
         slider {


### PR DESCRIPTION
This is an invalid declaration, and GTK+ 3.22 fails to load the theme with it.