### PR TITLE
Fix HeaderWidget & HeaderExpander expanded property mismatch

### DIFF
--- a/raven/headerwidget.vala
+++ b/raven/headerwidget.vala
@@ -66,6 +66,7 @@ public class HeaderWidget : Gtk.Box
     private Gtk.Label? label = null;
     private Gtk.Button? close_button = null;
     private Gtk.Box? header_box = null;
+    private HeaderExpander? expander_btn = null;
 
     /** Display text */
     public string? text {
@@ -156,8 +157,8 @@ public class HeaderWidget : Gtk.Box
 
         /* No custom end-widget, use an expander */
         if (end_widget == null) {
-            var expander = new HeaderExpander(this);
-            header_box.pack_end(expander, false, false, 0);
+            expander_btn = new HeaderExpander(this);
+            header_box.pack_end(expander_btn, false, false, 0);
         } else {
             header_box.pack_end(end_widget, false, false, 0);
         }
@@ -179,6 +180,13 @@ public class HeaderWidget : Gtk.Box
         this.icon_name = icon_name;
         this.can_close = can_close;
     }
+
+    public void notify_expanded_change(bool value)
+    {
+        if (expander_btn != null) {
+            expander_btn.expanded = value;
+        }
+    }
 }
 
 /**
@@ -193,6 +201,7 @@ public class RavenExpander : Gtk.Box
     public bool expanded {
         public set {
             content.set_reveal_child(value);
+            header.notify_expanded_change(value);
         }
         public get {
             return content.get_reveal_child();


### PR DESCRIPTION
As I pointed out in issue #561, Raven widgets that start collapsed, expand = false, have their HeaderExpander button in the wrong state: expanded. See the screenshot below.

![selection_001](https://cloud.githubusercontent.com/assets/1262461/19289299/757e7b1a-8fe0-11e6-9a1d-d9cf5475b7a3.png)

This issue happens because RavenExpander/HeaderWidget does not pass to the HeaderExpander button changes to the *expanded* property. So, when adding a widget that starts in a collapsed
state, the HeaderExpander is not updated accordingly, thus remaining in its default state, *expanded* = true, with the downwards arrow icon. 

This PR solves the bug.