### PR TITLE
Make all Raven Mpris clients, e.g. Spotify, start expanded

### DIFF
--- a/raven/mpris/MprisGui.vala
+++ b/raven/mpris/MprisGui.vala
@@ -83,7 +83,7 @@ public class ClientWidget : Gtk.Box
         var player_box = new Gtk.Box(Gtk.Orientation.VERTICAL, 0);
 
         header.can_close = client.player.can_quit;
-        player_revealer.expanded = header.can_close;
+        player_revealer.expanded = true;
 
         background = new ClientImage.from_icon_name("emblem-music-symbolic", Gtk.IconSize.INVALID);
         background.pixel_size = our_width;


### PR DESCRIPTION
This PR includes the second patch in the issue #561, to make all the Raven's music applets start expanded.

Raven was deciding whether to start Mpris clients expanded based on the property
'CanQuit' of the MediaPlayer2 dbus interface. But according to the interface
spec, this property should be used to know if we can close the application
through its Mpris client, e.g. through a close button in the client's UI.

So, this PR forgoes using CanQuit and simply sets the HeaderWidget of all MprisClients to expanded. 