### PR TITLE
Use default gravity (NORTH_WEST), otherwise positioning might be wrong

### DIFF
--- a/src/raven/raven.vala
+++ b/src/raven/raven.vala
@@ -339,8 +339,6 @@ public class Raven : Gtk.Window
             }
         });
 
-        set_gravity(Gdk.Gravity.NORTH_EAST);
-
         this.get_child().show_all();
     }
 


### PR DESCRIPTION
Fixes #583.
Interestingly, Compiz appears the only one WM among tested that actually respects this property.
Tested with Compiz and budgie-wm (from 10.2.8 release).