### PR TITLE
Ensure display of seconds on vertical panels is consistent #1246

### DIFF
--- a/src/applets/clock/ClockApplet.vala
+++ b/src/applets/clock/ClockApplet.vala
@@ -117,7 +117,6 @@ public class ClockApplet : Budgie.Applet
         layout.border_width = 0;
 
         seconds_label = new Gtk.Label("");
-        seconds_label.get_style_context().add_class("dim-label");
         layout.pack_start(seconds_label, false, false, 0);
         seconds_label.no_show_all = true;
         seconds_label.hide();
@@ -330,7 +329,7 @@ public class ClockApplet : Budgie.Applet
         if (this.orient == Gtk.Orientation.HORIZONTAL) {
             ftime = "";
         } else {
-            ftime = "<big>%S</big>";
+            ftime = "<small>%S</small>";
         }
 
         // Prevent unnecessary redraws


### PR DESCRIPTION
Font size for the date-time seconds label is now set to be
the same as for the date.
In addition, the dim-label class for the seconds label has been
removed to ensure consistency with the display on the horizontal
panel.