### PR TITLE
Obtain gsettings transparency key value before showing panel #1124

### DIFF
--- a/src/panel/manager.vala
+++ b/src/panel/manager.vala
@@ -1,14 +1,14 @@
 /*
  * This file is part of budgie-desktop
- * 
+ *
  * Copyright © 2015-2017 Budgie Desktop Developers
- * 
+ *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
  * (at your option) any later version.
  */
- 
+
 using LibUUID;
 
 namespace Budgie
@@ -1301,6 +1301,10 @@ public class PanelManager : DesktopManager
         load_panel(uuid, false);
 
         set_panels();
+
+        string path = this.create_panel_path(uuid);
+        var settings = new GLib.Settings.with_path(Budgie.TOPLEVEL_SCHEMA, path);
+        transparency = (PanelTransparency)settings.get_enum(Budgie.PANEL_KEY_TRANSPARENCY);
         show_panel(uuid, position, transparency);
 
         if (new_defaults == null || name == null) {


### PR DESCRIPTION
When creating a panel, the transparency key value needs to be
obtained before showing the panel. This allows transparency
panel gsettings overrides.