### PR TITLE
Implement broader Raven DND support and tweak Clear Notifications.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+	"editor.detectIndentation": true,
+	"[vala]": {
+		"editor.insertSpaces": true,
+		"editor.tabSize": 4
+	}
+}

--- a/src/raven/raven.vala
+++ b/src/raven/raven.vala
@@ -21,6 +21,9 @@ public class RavenIface
 
     private Raven? parent = null;
     [DBus (visible = false)]
+    private bool dnd_enabled = false;
+
+    [DBus (visible = false)]
     public uint notifications = 0;
 
     [DBus (visible = false)]
@@ -96,6 +99,7 @@ public class RavenIface
         }
     }
 
+    
     public signal void NotificationsChanged();
 
     public uint GetNotificationCount() {
@@ -108,6 +112,20 @@ public class RavenIface
     public string get_version()
     {
         return "1";
+    }
+
+    /**
+     * Do Not Disturb Functionality
+     */
+    public signal void DoNotDisturbChanged(bool active);
+
+    public bool GetDoNotDisturbState() {
+        return this.dnd_enabled;
+    }
+
+    public void SetDoNotDisturb(bool enable) {
+        this.dnd_enabled = enable;
+        this.DoNotDisturbChanged(this.dnd_enabled);
     }
 }
 
@@ -216,6 +234,11 @@ public class Raven : Gtk.Window
     public static unowned Raven? get_instance()
     {
         return Raven._instance;
+    }
+
+    public void set_dnd_state(bool active)
+    {
+        this.iface.SetDoNotDisturb(active); // Set the active state of our RavenIFace DND
     }
 
     public void set_notification_count(uint count)


### PR DESCRIPTION
Implements a dnd_enabled state in RavenIFace, as well as appropriate functionality for setting, fetching, and being updated on DND state changes. This is utilized by our Notifications Applet, which will now update the icon based on the DND state (defaults to not being in DND mode).

Additionally, tweaked the icon for enabling / disabling DND to being notification-alert-symbolic, to be consistent with the applet, and disabled being notification-disabled-symbolic.

This commit also tweaks the behavior of showing the Clear Notifications button, which will now only show if there are actual notifications to clear.

Added a .vscode workspace configuration to enforce spaces for Vala.