### PR TITLE
Budgie Menu: Added Pixbuf error handling and fallback.

### DIFF
--- a/src/applets/budgie-menu/BudgieMenu.vala
+++ b/src/applets/budgie-menu/BudgieMenu.vala
@@ -200,8 +200,13 @@ public class BudgieMenuApplet : Budgie.Applet
             case "menu-icon":
                 string? icon = settings.get_string(key);
                 if ("/" in icon) {
-                    Gdk.Pixbuf pixbuf = new Gdk.Pixbuf.from_file(icon);
-                    img.set_from_pixbuf(pixbuf.scale_simple(this.pixel_size, this.pixel_size, Gdk.InterpType.BILINEAR));
+                    try {
+                        Gdk.Pixbuf pixbuf = new Gdk.Pixbuf.from_file(icon);
+                        img.set_from_pixbuf(pixbuf.scale_simple(this.pixel_size, this.pixel_size, Gdk.InterpType.BILINEAR));
+                    } catch (Error e) {
+                        warning("Failed to update Budgie Menu applet icon: %s", e.message);
+                        img.set_from_icon_name("view-grid-symbolic", Gtk.IconSize.INVALID); // Revert to view-grid-symbolic
+                    }
                 } else if (icon == "") {
                     should_show = false;
                 } else {


### PR DESCRIPTION
Added error handling for when we fail to get a file from Gdk.Pixbuf.from_file. This can occur if the path is incorrect or the file disappears / is removed from the filesystem, so we fallback to view-grid-symbolic during this case.