### PR TITLE
Start requiring GTK 3.22 and Vala >=0.40.0. Cleanup deprecated APIs.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -32,8 +32,8 @@ am_cflags = [
 add_global_arguments(am_cflags, language: 'c')
 meson.add_install_script('meson_post_install.sh')
 
-# Budgie needs a minimum 3.18 GNOME stack
-gnome_minimum_version = '>= 3.18.0'
+# Budgie needs a minimum 3.22 GNOME stack
+gnome_minimum_version = '>= 3.22.0'
 
 dep_gtk3 = dependency('gtk+-3.0', version: gnome_minimum_version)
 dep_glib = dependency('glib-2.0', version: '>= 2.46.0')
@@ -41,9 +41,7 @@ dep_giounix = dependency('gio-unix-2.0', version: '>= 2.46.0')
 dep_peas = dependency('libpeas-1.0', version: '>= 1.8.0')
 dep_gdkx11 = dependency('gdk-x11-3.0', version: gnome_minimum_version)
 dep_libuuid = dependency('uuid')
-
-# gtk 3.18 needed for old APIs
-dep_gtk318 = dependency('gtk+-3.0', version: '< 3.19', required: false)
+dep_vala = dependency('vapigen', version: '>= 0.40.0')
 
 # Needed for keyboardy bits
 dep_ibus = dependency('ibus-1.0', version: '>= 1.5.10')

--- a/src/applets/status/PowerIndicator.vala
+++ b/src/applets/status/PowerIndicator.vala
@@ -17,7 +17,6 @@ public class BatteryIcon : Gtk.Box
 
     private Gtk.Image image;
 
-#if !HAVE_GTK_318
     private Gtk.Label percent_label;
 
     /**
@@ -34,14 +33,11 @@ public class BatteryIcon : Gtk.Box
         default = false;
     }
 
-#endif
-
     public BatteryIcon(Up.Device battery) {
         Object(orientation: Gtk.Orientation.HORIZONTAL, spacing: 0);
 
         this.get_style_context().add_class("battery-icon");
 
-#if !HAVE_GTK_318
         /* We'll optionally show percent labels */
         this.percent_label = new Gtk.Label("");
         this.percent_label.get_style_context().add_class("percent-label");
@@ -50,7 +46,6 @@ public class BatteryIcon : Gtk.Box
         this.percent_label.margin_end = 4;
         pack_start(this.percent_label, false, false, 0);
         this.percent_label.no_show_all = true;
-#endif
 
         this.image = new Gtk.Image();
         this.image.valign = Gtk.Align.CENTER;
@@ -114,14 +109,12 @@ public class BatteryIcon : Gtk.Box
                 tip = _("Battery remaining") + ": %d%% (%d:%02d)".printf((int)battery.percentage, hours, minutes);
         }
 
-#if !HAVE_GTK_318
         // Set the percentage label text if it's changed
         string labe = "%d%%".printf((int)battery.percentage);
         string old = this.percent_label.get_label();
         if (old != labe) {
             this.percent_label.set_text(labe);
         }
-#endif
 
         // Set a handy tooltip until we gain a menu in StatusApplet
         set_tooltip_text(tip);
@@ -143,12 +136,9 @@ public class PowerIndicator : Gtk.Bin
 
     private HashTable<string,BatteryIcon?> devices;
 
-#if !HAVE_GTK_318
     public bool label_visible { set ; get ; default = false; }
     private Gtk.CheckButton check_percent;
     private Settings battery_settings;
-#endif
-
 
     public PowerIndicator()
     {
@@ -164,7 +154,6 @@ public class PowerIndicator : Gtk.Bin
         box.border_width = 6;
         popover.add(box);
 
-#if !HAVE_GTK_318
         /* Instaniate label_visible */
         battery_settings = new Settings("org.gnome.desktop.interface");
         battery_settings.bind("show-battery-percentage", this, "label-visible", SettingsBindFlags.GET);
@@ -178,7 +167,6 @@ public class PowerIndicator : Gtk.Bin
 
         var sep = new Gtk.Separator(Gtk.Orientation.HORIZONTAL);
         box.pack_start(sep, false, false, 1);
-#endif
 
         var button = new Gtk.Button.with_label(_("Power settings"));
         button.get_style_context().add_class(Gtk.STYLE_CLASS_FLAT);
@@ -209,7 +197,6 @@ public class PowerIndicator : Gtk.Bin
         }
     }
 
-#if !HAVE_GTK_318
     private void update_labels()
     {
         unowned BatteryIcon? icon = null;
@@ -220,7 +207,6 @@ public class PowerIndicator : Gtk.Bin
         /* Fix glitching with Arc theming + "theme-regions" */
         this.get_toplevel().queue_draw();
     }
-#endif
 
     private bool is_interesting(Up.Device device)
     {
@@ -262,9 +248,7 @@ public class PowerIndicator : Gtk.Bin
             return;
         }
         var icon = new BatteryIcon(device);
-#if !HAVE_GTK_318
         icon.label_visible = this.label_visible;
-#endif
         devices.insert(object_path, icon);
         widget.pack_start(icon);
         toggle_show();

--- a/src/applets/status/meson.build
+++ b/src/applets/status/meson.build
@@ -36,11 +36,6 @@ if with_bluetooth == true
     applet_status_vala_args += ['-D', 'WITH_BLUETOOTH']
 endif
 
-# For old schemas that don't have show-battery-percentage
-if dep_gtk318.found()
-    applet_status_vala_args += ['-D', 'HAVE_GTK_318']
-endif
-
 shared_library(
     'statusapplet',
     applet_status_sources,

--- a/src/daemon/endsession.vala
+++ b/src/daemon/endsession.vala
@@ -135,7 +135,6 @@ public class EndSessionDialog : Gtk.Window
         Bus.own_name(BusType.SESSION, "org.budgie_desktop.Session.EndSessionDialog", flags,
             on_bus_acquired, ()=> {} , Budgie.DaemonNameLost);
         set_keep_above(true);
-        set_has_resize_grip(false);
         set_resizable(false);
 
         realize.connect(on_realized);
@@ -217,7 +216,12 @@ public class EndSessionDialog : Gtk.Window
         unowned Gdk.Window? win = get_window();
         if (win != null) {
             Gdk.Display? display = screen.get_display();
-            win.focus(Gdk.X11Display.get_user_time(display));
+
+            if (display is Gdk.X11.Display) {
+                win.focus((display as Gdk.X11.Display).get_user_time());
+            } else {
+                win.focus(Gtk.get_current_event_time());
+            }
         }
     }
 

--- a/src/daemon/osd.vala
+++ b/src/daemon/osd.vala
@@ -75,7 +75,7 @@ public class OSD : Gtk.Window
     /**
      * Track the primary monitor to show on
      */
-    private int primary_monitor;
+    private Gdk.Monitor primary_monitor;
 
     /**
      * Current text to display. NULL hides the widget.
@@ -188,7 +188,7 @@ public class OSD : Gtk.Window
      */
     private void on_monitors_changed()
     {
-        primary_monitor = screen.get_primary_monitor();
+        primary_monitor = screen.get_display().get_primary_monitor();
         move_osd();
     }
 
@@ -198,10 +198,7 @@ public class OSD : Gtk.Window
     public void move_osd()
     {
         /* Find the primary monitor bounds */
-        Gdk.Screen sc = get_screen();
-        Gdk.Rectangle bounds;
-
-        sc.get_monitor_geometry(primary_monitor, out bounds);
+        Gdk.Rectangle bounds = primary_monitor.get_geometry();
         Gtk.Allocation alloc;
 
         get_child().get_allocation(out alloc);

--- a/src/daemon/tabswitcher.vala
+++ b/src/daemon/tabswitcher.vala
@@ -95,7 +95,7 @@ public class TabSwitcherWindow : Gtk.Window
     /**
      * Track the primary monitor to show on
      */
-    private int primary_monitor;
+    private Gdk.Monitor primary_monitor;
 
     private HashTable<uint32, TabSwitcherWidget?> xids = null;
 
@@ -118,7 +118,7 @@ public class TabSwitcherWindow : Gtk.Window
 
         /* Get the window, which should be activated and activate that */
         TabSwitcherWidget? tab = current.get_child() as TabSwitcherWidget;
-        uint32 time = (uint32)Gdk.x11_get_server_time(Gdk.get_default_root_window());
+        uint32 time = (uint32)Gdk.X11.get_server_time(Gdk.get_default_root_window() as Gdk.X11.Window);
         tab.wnck_window.activate(time);
 
         /* Remove all items so if the widget gets shown again it starts from scratch */
@@ -179,7 +179,7 @@ public class TabSwitcherWindow : Gtk.Window
      */
     private void on_monitors_changed()
     {
-        primary_monitor = screen.get_primary_monitor();
+        primary_monitor = screen.get_display().get_primary_monitor();
         move_switcher();
     }
 
@@ -189,10 +189,7 @@ public class TabSwitcherWindow : Gtk.Window
     public void move_switcher()
     {
         /* Find the primary monitor bounds */
-        Gdk.Screen sc = get_screen();
-        Gdk.Rectangle bounds;
-
-        sc.get_monitor_geometry(primary_monitor, out bounds);
+        Gdk.Rectangle bounds = primary_monitor.get_geometry();
         Gtk.Allocation alloc;
 
         get_child().get_allocation(out alloc);
@@ -328,7 +325,7 @@ public class TabSwitcher : Object
     {
         mod_timeout = 0;
         Gdk.ModifierType modifier;
-        Gdk.Display.get_default().get_device_manager().get_client_pointer().get_state(Gdk.get_default_root_window(), null, out modifier);
+        Gdk.Display.get_default().get_default_seat().get_pointer().get_state(Gdk.get_default_root_window(), null, out modifier);
         if ((modifier & Gdk.ModifierType.MOD1_MASK) == 0 && (modifier & Gdk.ModifierType.MOD4_MASK) == 0) {
             switcher_window.hide();
             return false;

--- a/src/panel/meson.build
+++ b/src/panel/meson.build
@@ -79,11 +79,6 @@ if with_desktop_icons == 'nautilus'
     budgie_panel_vala_args += ['-D', 'HAVE_NAUTILUS']
 endif
 
-# For pointer methods
-if dep_gtk318.found()
-    budgie_panel_vala_args += ['-D', 'HAVE_GTK_318']
-endif
-
 budgie_panel_c_args = [
     '-DWNCK_I_KNOW_THIS_IS_UNSTABLE'
 ]

--- a/src/panel/panel.vala
+++ b/src/panel/panel.vala
@@ -1375,14 +1375,8 @@ public class Panel : Budgie.Toplevel
         var display = this.get_display();
         unowned Gdk.Device? pointer = null;
 
-        /* 3.18 and older use old API*/
-#if HAVE_GTK_318
-        var man = this.get_display().get_device_manager();
-        pointer = man.get_client_pointer();
-#else
         var seat = display.get_default_seat();
         pointer = seat.get_pointer();
-#endif
         this.get_position(out x, out y);
         this.get_size(out w, out h);
         pointer.get_position(null, out cx, out cy);

--- a/src/raven/raven.vala
+++ b/src/raven/raven.vala
@@ -267,8 +267,8 @@ public class Raven : Gtk.Window
         if (!has_toplevel_focus) {
             /* X11 specific. */
             Gdk.Display? display = screen.get_display();
-            if (display is Gdk.X11Display) {
-                window.focus(Gdk.X11Display.get_user_time(display));
+            if (display is Gdk.X11.Display) {
+                window.focus((display as Gdk.X11.Display).get_user_time());
             } else {
                 window.focus(Gtk.get_current_event_time());
             }

--- a/src/wm/background.vala
+++ b/src/wm/background.vala
@@ -12,13 +12,13 @@
 namespace Budgie {
 
  
-public static const string BACKGROUND_SCHEMA      = "org.gnome.desktop.background";
-public static const string PICTURE_URI_KEY        = "picture-uri";
-public static const string PRIMARY_COLOR_KEY      = "primary-color";
-public static const string SECONDARY_COLOR_KEY    = "secondary-color";
-public static const string COLOR_SHADING_TYPE_KEY = "color-shading-type";
-public static const string BACKGROUND_STYLE_KEY   = "picture-options";
-public static const string GNOME_COLOR_HACK       = "gnome-control-center/pixmaps/noise-texture-light.png";
+public const string BACKGROUND_SCHEMA      = "org.gnome.desktop.background";
+public const string PICTURE_URI_KEY        = "picture-uri";
+public const string PRIMARY_COLOR_KEY      = "primary-color";
+public const string SECONDARY_COLOR_KEY    = "secondary-color";
+public const string COLOR_SHADING_TYPE_KEY = "color-shading-type";
+public const string BACKGROUND_STYLE_KEY   = "picture-options";
+public const string GNOME_COLOR_HACK       = "gnome-control-center/pixmaps/noise-texture-light.png";
 
 public class BudgieBackground : Meta.BackgroundGroup
 {
@@ -33,7 +33,7 @@ public class BudgieBackground : Meta.BackgroundGroup
     private Clutter.Actor? old_bg = null;
     Meta.BackgroundImageCache? cache = null;
 
-    static const int BACKGROUND_TIMEOUT = 850;
+    const int BACKGROUND_TIMEOUT = 850;
 
 
     /* Ensure we're efficient with changed queries and dont update the WP

--- a/src/wm/ibus.vala
+++ b/src/wm/ibus.vala
@@ -148,7 +148,7 @@ public class IBusManager : GLib.Object
         return this.engines.lookup(name);
     }
 
-    static const int ENGINE_SET_TIMEOUT = 4000;
+    const int ENGINE_SET_TIMEOUT = 4000;
 
     /**
      * Set the ibus engine to the specified engine name

--- a/src/wm/keyboard.vala
+++ b/src/wm/keyboard.vala
@@ -12,11 +12,11 @@
 
 namespace Budgie {
 
-public static const string DEFAULT_LOCALE = "en_US";
-public static const string DEFAULT_LAYOUT = "us";
-public static const string DEFAULT_VARIANT = "";
+public const string DEFAULT_LOCALE = "en_US";
+public const string DEFAULT_LAYOUT = "us";
+public const string DEFAULT_VARIANT = "";
 /* Default ibus engine to use */
-public static const string DEFAULT_ENGINE = "xkb:us::eng";
+public const string DEFAULT_ENGINE = "xkb:us::eng";
 
 errordomain InputMethodError {
     UNKNOWN_IME

--- a/src/wm/wm.vala
+++ b/src/wm/wm.vala
@@ -157,7 +157,7 @@ public class BudgieWM : Meta.Plugin
     Clutter.Actor? screen_group;
     ulong current_window_resize;
 
-    static construct
+    construct
     {
         info = Meta.PluginInfo() {
             name = "Budgie WM",
@@ -394,7 +394,7 @@ public class BudgieWM : Meta.Plugin
     }
 
     delegate unowned string GlQueryFunc(uint id);
-    static const uint GL_VENDOR = 0x1F00;
+    const uint GL_VENDOR = 0x1F00;
 
     private bool is_nvidia()
     {
@@ -568,14 +568,14 @@ public class BudgieWM : Meta.Plugin
         }
     }
 
-    static const int MAP_TIMEOUT  = 100;
-    static const int MENU_MAP_TIMEOUT = 120;
-    static const float MAP_SCALE  = 0.94f;
-    static const float MENU_MAP_SCALE_X = 0.98f;
-    static const float MENU_MAP_SCALE_Y = 0.95f;
-    static const float NOTIFICATION_MAP_SCALE_X  = 0.5f;
-    static const float NOTIFICATION_MAP_SCALE_Y  = 0.8f;
-    static const int FADE_TIMEOUT = 145;
+    const int MAP_TIMEOUT  = 100;
+    const int MENU_MAP_TIMEOUT = 120;
+    const float MAP_SCALE  = 0.94f;
+    const float MENU_MAP_SCALE_X = 0.98f;
+    const float MENU_MAP_SCALE_Y = 0.95f;
+    const float NOTIFICATION_MAP_SCALE_X  = 0.5f;
+    const float NOTIFICATION_MAP_SCALE_Y  = 0.8f;
+    const int FADE_TIMEOUT = 145;
 
     void finalize_animations(Meta.WindowActor? actor)
     {
@@ -671,7 +671,6 @@ public class BudgieWM : Meta.Plugin
                 actor.set_easing_duration(MENU_MAP_TIMEOUT);
 
                 actor.set("scale-x", 1.0, "scale-y", 1.0, "opacity", 255U);
-                break;
                 break;
             case Meta.WindowType.NOTIFICATION:
                 if (window.get_wm_class() == "raven") {
@@ -872,7 +871,7 @@ public class BudgieWM : Meta.Plugin
         finalize_animations(actor as Meta.WindowActor);
     }
 
-    static const int MINIMIZE_TIMEOUT = 195;
+    const int MINIMIZE_TIMEOUT = 195;
 
     public override void minimize(Meta.WindowActor actor)
     {
@@ -927,7 +926,7 @@ public class BudgieWM : Meta.Plugin
         finalize_animations(actor as Meta.WindowActor);
     }
 
-    static const int UNMINIMIZE_TIMEOUT = 170;
+    const int UNMINIMIZE_TIMEOUT = 170;
 
     /**
      * Handle unminimize animation
@@ -973,8 +972,8 @@ public class BudgieWM : Meta.Plugin
         finalize_animations(actor as Meta.WindowActor);
     }
 
-    static const int DESTROY_TIMEOUT  = 120;
-    static const double DESTROY_SCALE = 0.88;
+    const int DESTROY_TIMEOUT  = 120;
+    const double DESTROY_SCALE = 0.88;
 
     public override void destroy(Meta.WindowActor actor)
     {
@@ -1141,7 +1140,7 @@ public class BudgieWM : Meta.Plugin
         }
     }
 
-    public static const uint32 MAX_TAB_ELAPSE = 2000;
+    public const uint32 MAX_TAB_ELAPSE = 2000;
 
     public void switch_windows_backward(Meta.Display display, Meta.Screen screen,
                      Meta.Window? window, Clutter.KeyEvent? event,
@@ -1286,7 +1285,7 @@ public class BudgieWM : Meta.Plugin
     }
 
 
-    public static const int SWITCH_TIMEOUT = 250;
+    public const int SWITCH_TIMEOUT = 250;
     public override void switch_workspace(int from, int to, Meta.MotionDirection direction)
     {
         // Stop the Switcher if it was showing


### PR DESCRIPTION
As of this commit, we now require GTK 3.22 or above, as well as a modern release of Vala.

- Changed usage Gdk.X11Display/Gdk.X11Screen to Gdk.X11.Display/Screen.
- Updated modifier state fetching, which resolves the following deprecation warnings:
  - Gdk.Display.get_device_manager has been deprecated since 3.20.
  - Gdk.DeviceManager.get_client_pointer has been deprecated since 3.20
- Fixed monitor fetching using the following deprecated APIs across tabswitcher and osd.
  - Gdk.Screen.get_primary_monitor has been deprecated since 3.22
  - Gdk.Screen.get_monitor_geometry has been deprecated since 3.22
- Vala: static const is no longer a thing (in Vala >=0.34.0), switch references to const.

Note: Use of Gtk.Menu.popup has not been deprecated from our codebase. Requires some further tinkering.