### PR TITLE
Avoid some deprecated Gdk.Screen functions in lib/toplevel and raven/notifications_view

### DIFF
--- a/src/lib/toplevel.vala
+++ b/src/lib/toplevel.vala
@@ -59,11 +59,10 @@ public abstract class Toplevel : Gtk.Window
 public static void set_struts(Gtk.Window? window, PanelPosition position, long panel_size)
 {
     Gdk.Atom atom;
-    Gdk.Rectangle primary_monitor_rect;
     long struts[12] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
     var screen = window.screen;
-    var mon = screen.get_primary_monitor();
-    screen.get_monitor_geometry(mon, out primary_monitor_rect);
+    Gdk.Monitor mon = screen.get_display().get_primary_monitor();
+    Gdk.Rectangle primary_monitor_rect = mon.get_geometry();
     /*
     strut-left strut-right strut-top strut-bottom
     strut-left-start-y   strut-left-end-y

--- a/src/raven/notifications_view.vala
+++ b/src/raven/notifications_view.vala
@@ -680,14 +680,12 @@ public class NotificationsView : Gtk.Box
     {
         int x = 0;
         int y = 0;
-        Gdk.Rectangle rect;
 
         unowned NotificationWindow? tail = stack.peek_head();
         var screen = Gdk.Screen.get_default();
 
-        int mon = screen.get_primary_monitor();
-
-        screen.get_monitor_geometry(mon, out rect);
+        Gdk.Monitor mon = screen.get_display().get_primary_monitor();
+        Gdk.Rectangle rect = mon.get_geometry();
 
         if (tail != null) {
             int nx;


### PR DESCRIPTION
Additional fix for https://github.com/solus-project/budgie-desktop/pull/1458

Fixed warning:
Gdk.Screen.get_primary_monitor has been deprecated since 3.22
Gdk.Screen.get_monitor_geometry has been deprecated since 3.22