### PR TITLE
Improved (fixed) meson.build

### DIFF
--- a/src/wm/meson.build
+++ b/src/wm/meson.build
@@ -20,22 +20,28 @@ dep_mutter = dependency('libmutter', version: gnome_minimum_version, required: f
 
 if not dep_mutter.found()
     dep_mutter = dependency('libmutter-0', version: gnome_minimum_version, required: false)
-    message('Using stable libmutter-0 ABI from GNOME 3.24')
-    vapi_mutter = 'libmutter-0'
+    if dep_mutter.found()
+        message('Using stable libmutter-0 ABI from GNOME 3.24')
+        vapi_mutter = 'libmutter-0'
+    endif
 endif
 
 # now try libmutter-1 ...
 if not dep_mutter.found()
     dep_mutter = dependency('libmutter-1', version: gnome_minimum_version, required: false)
-    message('Using new libmutter-1 ABI from GNOME 3.26')
-    vapi_mutter = 'libmutter-1'
+    if dep_mutter.found()
+        message('Using new libmutter-1 ABI from GNOME 3.26')
+        vapi_mutter = 'libmutter-1'
+    endif
 endif
 
 # now try libmutter-2 ...
 if not dep_mutter.found()
     dep_mutter = dependency('libmutter-2', version: gnome_minimum_version)
-    message('Using new libmutter-2 ABI from GNOME 3.28')
-    vapi_mutter = 'libmutter-2'
+    if dep_mutter.found()
+        message('Using new libmutter-2 ABI from GNOME 3.28')
+        vapi_mutter = 'libmutter-2'
+    endif
 endif
 
 budgie_wm_deps = [


### PR DESCRIPTION
Previously meson.build would print "Using libmutter-X ..." messages without checking if the dependency was found, leading to the case where if running on a system with libmutter-2 (Arch Linux) one would see

Dependency libmutter found: NO
Dependency libmutter-0 found: NO
Message: Using stable libmutter-0 ABI from GNOME 3.24
Dependency libmutter-1 found: NO
Message: Using new libmutter-1 ABI from GNOME 3.26
Native dependency libmutter-2 found: YES 3.28.2
Message: Using new libmutter-2 ABI from GNOME 3.28

Which is not terrible, but led to a bit of debugging / musing over the build file before I realized it had in fact properly completed the meson-build process. The new output should be more quickly understandable (and not print erroneous messages)

Dependency libmutter found: NO
Dependency libmutter-0 found: NO
Dependency libmutter-1 found: NO
Native dependency libmutter-2 found: YES 3.28.2
Message: Using new libmutter-2 ABI from GNOME 3.28