### PR TITLE
Hide add workspace button during initialization

### DIFF
--- a/src/applets/workspaces/WorkspacesApplet.vala
+++ b/src/applets/workspaces/WorkspacesApplet.vala
@@ -114,6 +114,7 @@ public class WorkspacesApplet : Budgie.Applet
 
         add_button_revealer = new Gtk.Revealer();
         add_button_revealer.set_transition_duration(200);
+        add_button_revealer.set_transition_type(hide_transition);
         add_button_revealer.set_reveal_child(false);
 
         Gtk.Button add_button = new Gtk.Button.from_icon_name("list-add-symbolic", Gtk.IconSize.MENU);


### PR DESCRIPTION
When starting `budgie-panel` with the "add workspace button" set to "don't show" there may sometimes be an empty placeholder in the workspace applet.

![before](https://user-images.githubusercontent.com/532268/42283843-05fd7964-7fab-11e8-886b-038d2350af7d.png)

This pull request changes the initialization of the revealer, making sure that the area isn't visible when the applet is created.

![after](https://user-images.githubusercontent.com/532268/42284301-67f6c93a-7fac-11e8-92f6-aa656b4f8358.png)

The other modes still appear to work as expected when starting `budgie-panel`.