### PR TITLE
Implement new Sound Output and Input Widgets in Raven.

### DIFF
--- a/src/applets/budgie-menu/BudgieMenu.vala
+++ b/src/applets/budgie-menu/BudgieMenu.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  * 
- * Copyright © 2015-2017 Budgie Desktop Developers
+ * Copyright © 2015-2018 Budgie Desktop Developers
  * 
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/budgie-menu/BudgieMenuWindow.vala
+++ b/src/applets/budgie-menu/BudgieMenuWindow.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  * 
- * Copyright © 2015-2017 Budgie Desktop Developers
+ * Copyright © 2015-2018 Budgie Desktop Developers
  * 
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/keyboard-layout/KeyboardLayoutApplet.vala
+++ b/src/applets/keyboard-layout/KeyboardLayoutApplet.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  * 
- * Copyright © 2015-2017 Budgie Desktop Developers
+ * Copyright © 2015-2018 Budgie Desktop Developers
  * 
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/lock-keys/LockKeysApplet.vala
+++ b/src/applets/lock-keys/LockKeysApplet.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  * 
- * Copyright © 2015-2017 Budgie Desktop Developers
+ * Copyright © 2015-2018 Budgie Desktop Developers
  * 
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/notifications/NotificationsApplet.vala
+++ b/src/applets/notifications/NotificationsApplet.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  * 
- * Copyright © 2015-2017 Budgie Desktop Developers
+ * Copyright © 2015-2018 Budgie Desktop Developers
  * 
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/places-indicator/ListItem.vala
+++ b/src/applets/places-indicator/ListItem.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2015-2017 Budgie Desktop Developers
+ * Copyright © 2015-2018 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/places-indicator/MessageRevealer.vala
+++ b/src/applets/places-indicator/MessageRevealer.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2015-2017 Budgie Desktop Developers
+ * Copyright © 2015-2018 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/places-indicator/MountHelper.vala
+++ b/src/applets/places-indicator/MountHelper.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2015-2017 Budgie Desktop Developers
+ * Copyright © 2015-2018 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/places-indicator/MountItem.vala
+++ b/src/applets/places-indicator/MountItem.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2015-2017 Budgie Desktop Developers
+ * Copyright © 2015-2018 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/places-indicator/PlaceItem.vala
+++ b/src/applets/places-indicator/PlaceItem.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2015-2017 Budgie Desktop Developers
+ * Copyright © 2015-2018 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/places-indicator/PlacesIndicator.vala
+++ b/src/applets/places-indicator/PlacesIndicator.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2015-2017 Budgie Desktop Developers
+ * Copyright © 2015-2018 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/places-indicator/PlacesIndicatorWindow.vala
+++ b/src/applets/places-indicator/PlacesIndicatorWindow.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2015-2017 Budgie Desktop Developers
+ * Copyright © 2015-2018 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/places-indicator/PlacesSection.vala
+++ b/src/applets/places-indicator/PlacesSection.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2015-2017 Budgie Desktop Developers
+ * Copyright © 2015-2018 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/places-indicator/VolumeItem.vala
+++ b/src/applets/places-indicator/VolumeItem.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2015-2017 Budgie Desktop Developers
+ * Copyright © 2015-2018 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/raven-trigger/RavenTriggerApplet.vala
+++ b/src/applets/raven-trigger/RavenTriggerApplet.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  * 
- * Copyright © 2015-2017 Budgie Desktop Developers
+ * Copyright © 2015-2018 Budgie Desktop Developers
  * 
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/separator/SeparatorApplet.vala
+++ b/src/applets/separator/SeparatorApplet.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  * 
- * Copyright © 2015-2017 Budgie Desktop Developers
+ * Copyright © 2015-2018 Budgie Desktop Developers
  * 
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/show-desktop/ShowDesktopApplet.vala
+++ b/src/applets/show-desktop/ShowDesktopApplet.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  * 
- * Copyright © 2015-2017 Budgie Desktop Developers
+ * Copyright © 2015-2018 Budgie Desktop Developers
  * 
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/spacer/SpacerApplet.vala
+++ b/src/applets/spacer/SpacerApplet.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  * 
- * Copyright © 2015-2017 Budgie Desktop Developers
+ * Copyright © 2015-2018 Budgie Desktop Developers
  * 
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/status/BluetoothIndicator.vala
+++ b/src/applets/status/BluetoothIndicator.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2015-2017 Budgie Desktop Developers
+ * Copyright © 2015-2018 Budgie Desktop Developers
  * Copyright (C) 2015 Alberts Muktupāvels
  *
  * This program is free software; you can redistribute it and/or modify

--- a/src/applets/status/PowerIndicator.vala
+++ b/src/applets/status/PowerIndicator.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2015-2017 Budgie Desktop Developers
+ * Copyright © 2015-2018 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/status/SoundIndicator.vala
+++ b/src/applets/status/SoundIndicator.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  * 
- * Copyright © 2015-2017 Budgie Desktop Developers
+ * Copyright © 2015-2018 Budgie Desktop Developers
  * 
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/status/StatusApplet.vala
+++ b/src/applets/status/StatusApplet.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2015-2017 Budgie Desktop Developers
+ * Copyright © 2015-2018 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/tasklist/TasklistApplet.vala
+++ b/src/applets/tasklist/TasklistApplet.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  * 
- * Copyright © 2015-2017 Budgie Desktop Developers
+ * Copyright © 2015-2018 Budgie Desktop Developers
  * 
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/tray/TrayApplet.vala
+++ b/src/applets/tray/TrayApplet.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2015-2017 Budgie Desktop Developers
+ * Copyright © 2015-2018 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/user-indicator/DBusInterfaces.vala
+++ b/src/applets/user-indicator/DBusInterfaces.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2015-2017 Budgie Desktop Developers
+ * Copyright © 2015-2018 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/user-indicator/UserIndicator.vala
+++ b/src/applets/user-indicator/UserIndicator.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  * 
- * Copyright © 2015-2017 Budgie Desktop Developers
+ * Copyright © 2015-2018 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/user-indicator/UserIndicatorWindow.vala
+++ b/src/applets/user-indicator/UserIndicatorWindow.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2015-2017 Budgie Desktop Developers
+ * Copyright © 2015-2018 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/daemon/endsession.vala
+++ b/src/daemon/endsession.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  * 
- * Copyright © 2015-2017 Budgie Desktop Developers
+ * Copyright © 2015-2018 Budgie Desktop Developers
  * 
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/lib/animation.vala
+++ b/src/lib/animation.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  * 
- * Copyright © 2015-2017 Budgie Desktop Developers
+ * Copyright © 2015-2018 Budgie Desktop Developers
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/lib/manager.vala
+++ b/src/lib/manager.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop.
  *
- * Copyright © 2015-2017 Budgie Desktop Developers
+ * Copyright © 2015-2018 Budgie Desktop Developers
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/lib/shadow.vala
+++ b/src/lib/shadow.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop.
  *
- * Copyright © 2015-2017 Budgie Desktop Developers
+ * Copyright © 2015-2018 Budgie Desktop Developers
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/lib/toplevel.vala
+++ b/src/lib/toplevel.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop.
  *
- * Copyright © 2015-2017 Budgie Desktop Developers
+ * Copyright © 2015-2018 Budgie Desktop Developers
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/libsession/libsession.vala
+++ b/src/libsession/libsession.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop.
  *
- * Copyright © 2015-2017 Budgie Desktop Developers
+ * Copyright © 2015-2018 Budgie Desktop Developers
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/panel/budgie-desktop-settings.vala
+++ b/src/panel/budgie-desktop-settings.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  * 
- * Copyright © 2015-2017 Budgie Desktop Developers
+ * Copyright © 2015-2018 Budgie Desktop Developers
  * 
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/panel/main.vala
+++ b/src/panel/main.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  * 
- * Copyright © 2015-2017 Budgie Desktop Developers
+ * Copyright © 2015-2018 Budgie Desktop Developers
  * 
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/panel/manager.vala
+++ b/src/panel/manager.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  * 
- * Copyright © 2015-2017 Budgie Desktop Developers
+ * Copyright © 2015-2018 Budgie Desktop Developers
  * 
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/panel/panel.vala
+++ b/src/panel/panel.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  * 
- * Copyright © 2015-2017 Budgie Desktop Developers
+ * Copyright © 2015-2018 Budgie Desktop Developers
  * 
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/panel/settings/settings_applet_chooser.vala
+++ b/src/panel/settings/settings_applet_chooser.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  * 
- * Copyright © 2015-2017 Budgie Desktop Developers
+ * Copyright © 2015-2018 Budgie Desktop Developers
  * 
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/panel/settings/settings_desktop.vala
+++ b/src/panel/settings/settings_desktop.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  * 
- * Copyright © 2015-2017 Budgie Desktop Developers
+ * Copyright © 2015-2018 Budgie Desktop Developers
  * 
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/panel/settings/settings_fonts.vala
+++ b/src/panel/settings/settings_fonts.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  * 
- * Copyright © 2015-2017 Budgie Desktop Developers
+ * Copyright © 2015-2018 Budgie Desktop Developers
  * 
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/panel/settings/settings_item.vala
+++ b/src/panel/settings/settings_item.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  * 
- * Copyright © 2015-2017 Budgie Desktop Developers
+ * Copyright © 2015-2018 Budgie Desktop Developers
  * 
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/panel/settings/settings_main.vala
+++ b/src/panel/settings/settings_main.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  * 
- * Copyright © 2015-2017 Budgie Desktop Developers
+ * Copyright © 2015-2018 Budgie Desktop Developers
  * 
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/panel/settings/settings_page.vala
+++ b/src/panel/settings/settings_page.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  * 
- * Copyright © 2015-2017 Budgie Desktop Developers
+ * Copyright © 2015-2018 Budgie Desktop Developers
  * 
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/panel/settings/settings_panel.vala
+++ b/src/panel/settings/settings_panel.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  * 
- * Copyright © 2015-2017 Budgie Desktop Developers
+ * Copyright © 2015-2018 Budgie Desktop Developers
  * 
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/panel/settings/settings_panel_applets.vala
+++ b/src/panel/settings/settings_panel_applets.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  * 
- * Copyright © 2015-2017 Budgie Desktop Developers
+ * Copyright © 2015-2018 Budgie Desktop Developers
  * 
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/panel/settings/settings_style.vala
+++ b/src/panel/settings/settings_style.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2015-2017 Budgie Desktop Developers
+ * Copyright © 2015-2018 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/panel/settings/settings_wm.vala
+++ b/src/panel/settings/settings_wm.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  * 
- * Copyright © 2015-2017 Budgie Desktop Developers
+ * Copyright © 2015-2018 Budgie Desktop Developers
  * 
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/panel/settings/themes.vala
+++ b/src/panel/settings/themes.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  * 
- * Copyright © 2015-2017 Budgie Desktop Developers
+ * Copyright © 2015-2018 Budgie Desktop Developers
  * 
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/panel/uuid.vala
+++ b/src/panel/uuid.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop.
  *
- * Copyright © 2015-2017 Budgie Desktop Developers
+ * Copyright © 2015-2018 Budgie Desktop Developers
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/polkit/polkitdialog.vala
+++ b/src/polkit/polkitdialog.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  * 
- * Copyright © 2015-2017 Budgie Desktop Developers
+ * Copyright © 2015-2018 Budgie Desktop Developers
  * 
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/raven/app_sound_control.vala
+++ b/src/raven/app_sound_control.vala
@@ -1,0 +1,151 @@
+/*
+ * This file is part of budgie-desktop
+ * 
+ * Copyright © 2015-2018 Budgie Desktop Developers
+ * 
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ */
+
+namespace Budgie {
+    public class AppSoundControl : Gtk.Box {
+        private Gvc.MixerControl? mixer = null;
+        private Gvc.MixerStream? primary_stream = null;
+        private Gvc.MixerStream? stream = null;
+        private Gtk.Image? app_image = null;
+        private Gtk.Label? app_label = null;
+        private Gtk.Scale? volume_slider = null;
+        private string? app_name = "";
+        private ulong scale_id;
+
+        public AppSoundControl(Gvc.MixerControl c_mixer, Gvc.MixerStream c_primary, Gvc.MixerStream c_stream, string c_icon) {
+            Object(orientation: Gtk.Orientation.HORIZONTAL, margin: 10);
+            valign = Gtk.Align.START;
+
+            mixer = c_mixer;
+            primary_stream = c_primary;
+            stream = c_stream;
+            app_name = stream.get_name();
+
+            var max_vol = stream.get_volume();
+            var primary_stream_vol = primary_stream.get_base_volume();
+
+            if (max_vol < primary_stream_vol) {
+                max_vol = primary_stream_vol;
+                stream.set_volume(primary_stream_vol);
+                Gvc.push_volume(stream); // Immediately push this update volume
+            }
+
+            stdout.printf("Added %s with max volume: %u\n", app_name, max_vol);
+
+            var max_vol_step = max_vol / 20;
+
+            /**
+             * App Desktop Logic
+             * Firstly, check if the app name has a related desktop app info, and if so use the desktop name for the application.
+             * Otherwise, use a titlized form of the app name if it'd match up with the description. Otherwise use app name.
+             */
+            bool successfully_retrieved_name = false;
+
+            try {
+                DesktopAppInfo info = new DesktopAppInfo(app_name + ".desktop"); // Attempt to get the application info
+
+                if (info != null) {
+                    string desktop_app_name = info.get_string("Name");
+
+                    if ((desktop_app_name != "") && (desktop_app_name != null)) { // If we got the desktop app name
+                        app_name = desktop_app_name;
+                        successfully_retrieved_name = true;
+                    }
+                }
+            } catch (Error e) {
+                warning("Failed to get app info for this app: %s", e.message);
+            }
+
+            if (!successfully_retrieved_name) { // If we failed to get info from a desktop file
+                string titled_app_name = app_name.substring(0,1).ascii_up() + app_name.substring(1);
+                string description = stream.get_description();
+
+                if (titled_app_name == description) {
+                    app_name = description;
+                }
+            }
+
+            /**
+             * Create initial elements
+             */
+            Gtk.Box app_info = new Gtk.Box(Gtk.Orientation.VERTICAL, 0);
+
+            app_label = new Gtk.Label(app_name); // Create a new label with the app name
+            app_label.halign = Gtk.Align.START; // Align to edge (left for LTR; right for RTL)
+            app_label.justify = Gtk.Justification.LEFT;
+            app_label.margin_left = 10;
+
+            volume_slider = new Gtk.Scale.with_range(Gtk.Orientation.HORIZONTAL, 0, max_vol, max_vol_step);
+            volume_slider.set_draw_value(false);
+            volume_slider.set_increments(max_vol_step, max_vol_step);
+            volume_slider.set_value(stream.get_volume());
+            scale_id = volume_slider.value_changed.connect(on_slider_change);
+
+            app_info.pack_start(app_label, true, false, 0);
+            app_info.pack_end(volume_slider, true, false, 0);
+
+            /**
+             * Icon logic
+             */
+            string stream_name = stream.get_name();
+
+            try { // First let's try to get a reasonable app icon instead of whatever is provided by Gvc
+                Gtk.IconTheme current_theme = Gtk.IconTheme.get_default(); // Get our default IconTheme
+                string usable_icon_name = current_theme.has_icon(stream_name) ? stream_name : c_icon; // If our app has an icon, use it, otherwise use the stream icon name
+                app_image = new Gtk.Image.from_icon_name(usable_icon_name, Gtk.IconSize.DND);
+            } catch (Error e) { // If we failed to create a Gtk.Image with the app name
+                warning("Failed to get an icon for this app. %s", e.message);
+            }
+
+            if (app_image != null) {
+                app_image.margin_end = 10;
+                pack_start(app_image, false, false, 0);
+            }
+
+            pack_end(app_info, true, true, 0);
+        }
+
+        /**
+         * on_slider_change will handle when our volume_slider scale changes
+         */
+        public void on_slider_change() {
+            var slider_value = volume_slider.get_value();
+
+            SignalHandler.block(volume_slider, scale_id);
+            stream.set_is_muted(slider_value == 0); // Set muted if slider_value is 0
+
+            if (stream.set_volume((uint32) slider_value)) {
+               Gvc.push_volume(stream);
+            }
+
+            SignalHandler.unblock(volume_slider, scale_id);
+        }
+
+        /**
+         * refresh is responsible for performing UI refresh / updating
+         */
+        public void refresh() {
+            var stream_name = stream.get_name();
+
+            if (app_name != stream_name) { // If the application name has changed
+                app_name = stream_name;
+                app_label.label = stream_name;
+            }
+
+            var vol = stream.get_volume();
+
+            if (volume_slider.get_value() != vol) { // If the volume has changed
+                volume_slider.set_value(vol); // Update volume slider value
+                stream.set_is_muted(vol == 0); // Set the app to be muted if vol is now 0
+            }
+        }
+    }
+}

--- a/src/raven/calendar.vala
+++ b/src/raven/calendar.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2015-2017 Budgie Desktop Developers
+ * Copyright © 2015-2018 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -23,6 +23,8 @@ public class CalendarWidget : Gtk.Box
         var time = new DateTime.now_local();
         header = new Budgie.HeaderWidget(time.format(date_format), "x-office-calendar-symbolic", false);
         var expander = new Budgie.RavenExpander(header);
+        expander.expanded = true;
+
         this.pack_start(expander, false, false, 0);
 
         cal = new Gtk.Calendar();

--- a/src/raven/headerwidget.vala
+++ b/src/raven/headerwidget.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  * 
- * Copyright © 2015-2017 Budgie Desktop Developers
+ * Copyright © 2015-2018 Budgie Desktop Developers
  * 
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -19,7 +19,7 @@ public class HeaderExpander : Gtk.Button
 {
     private Gtk.Image? image;
 
-    private bool _expanded = true;
+    private bool _expanded = false;
     private unowned HeaderWidget? owner = null;
 
     public bool expanded {
@@ -34,6 +34,7 @@ public class HeaderExpander : Gtk.Button
         public get {
             return this._expanded;
         }
+        default = false;
     }
 
     public HeaderExpander(HeaderWidget? owner)
@@ -53,7 +54,7 @@ public class HeaderExpander : Gtk.Button
     public override void clicked()
     {
         this.expanded = !this.expanded;
-        this.owner.expanded = expanded;
+        this.owner.expanded = this.expanded;
     }
 }
 
@@ -66,7 +67,7 @@ public class HeaderWidget : Gtk.Box
     private Gtk.Label? label = null;
     private Gtk.Button? close_button = null;
     private Gtk.Box? header_box = null;
-    private HeaderExpander? expander_btn = null;
+    public HeaderExpander? expander_btn = null;
 
     /** Display text */
     public string? text {
@@ -121,7 +122,7 @@ public class HeaderWidget : Gtk.Box
     /**
      * Manage the expanded state of this expanding header widget
      */
-    public bool expanded { public get; public set ; default = true; }
+    public bool expanded { public get; public set ; }
 
     /**
      * Emitted when this widget has been closed
@@ -185,6 +186,7 @@ public class HeaderWidget : Gtk.Box
     {
         if (expander_btn != null) {
             expander_btn.expanded = value;
+            expanded = value;
         }
     }
 }
@@ -206,7 +208,6 @@ public class RavenExpander : Gtk.Box
         public get {
             return content.get_reveal_child();
         }
-        default = true;
     }
 
     private bool track_animations = false;
@@ -226,7 +227,6 @@ public class RavenExpander : Gtk.Box
             this.get_toplevel().queue_draw();
             this.track_animations = false;
         });
-        expanded = true;
 
         content.notify["reveal-child"].connect(()=> {
             this.track_animations = true;

--- a/src/raven/main_view.vala
+++ b/src/raven/main_view.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  * 
- * Copyright © 2015-2017 Budgie Desktop Developers
+ * Copyright © 2015-2018 Budgie Desktop Developers
  * 
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -18,7 +18,8 @@ public class MainView : Gtk.Box
     /* This is completely temporary. Shush */
     private MprisWidget? mpris = null;
     private CalendarWidget? cal = null;
-    private SoundWidget? sound = null;
+    private Budgie.SoundWidget? audio_input_widget = null;
+    private Budgie.SoundWidget? audio_output_widget = null;
 
     private Gtk.Stack? main_stack = null;
     private Gtk.StackSwitcher? switcher = null;
@@ -66,8 +67,11 @@ public class MainView : Gtk.Box
         cal = new CalendarWidget();
         box.pack_start(cal, false, false, 0);
 
-        sound = new SoundWidget();
-        box.pack_start(sound, false, false, 0);
+        audio_output_widget = new Budgie.SoundWidget("output");
+        box.pack_start(audio_output_widget, false, false, 0);
+
+        audio_input_widget = new Budgie.SoundWidget("input");
+        box.pack_start(audio_input_widget, false, false, 0);
 
         mpris = new MprisWidget();
         box.pack_start(mpris, false, false, 0);
@@ -77,7 +81,6 @@ public class MainView : Gtk.Box
         main_stack.set_visible_child_name("applets");
 
         main_stack.notify["visible-child-name"].connect(on_name_change);
-
     }
 
     void on_name_change()

--- a/src/raven/meson.build
+++ b/src/raven/meson.build
@@ -12,6 +12,7 @@ libraven_resources = gnome.compile_resources(
 )
 
 libraven_sources = [
+    'app_sound_control.vala',
     'calendar.vala',
     'headerwidget.vala',
     'main_view.vala',
@@ -22,6 +23,7 @@ libraven_sources = [
     'mpris/MprisClient.vala',
     'mpris/MprisGui.vala',
     'mpris/MprisWidget.vala',
+    'start_listening.vala',
     libraven_resources,
 ]
 

--- a/src/raven/mpris/MprisClient.vala
+++ b/src/raven/mpris/MprisClient.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  * 
- * Copyright © 2015-2017 Budgie Desktop Developers
+ * Copyright © 2015-2018 Budgie Desktop Developers
  * 
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/raven/mpris/MprisGui.vala
+++ b/src/raven/mpris/MprisGui.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  * 
- * Copyright © 2015-2017 Budgie Desktop Developers
+ * Copyright © 2015-2018 Budgie Desktop Developers
  * 
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -202,6 +202,17 @@ public class ClientWidget : Gtk.Box
         });
 
         player_box.get_style_context().add_class("raven-background");
+
+        /**
+         * Custom Player Styling
+         * We do this against the parent box itself so styling includes the header
+         */
+        if ((client.player.desktop_entry != null) && (client.player.desktop_entry != "")) { // If a desktop entry is set
+            get_style_context().add_class(client.player.desktop_entry); // Add our desktop entry, such as "spotify" to player_box
+        } else { // If no desktop entry is set, use identity
+            get_style_context().add_class(client.player.identity.down()); // Lowercase identity
+        }
+
         player_revealer.add(player_box);
         pack_start(player_revealer);
     }

--- a/src/raven/mpris/MprisWidget.vala
+++ b/src/raven/mpris/MprisWidget.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  * 
- * Copyright © 2015-2017 Budgie Desktop Developers
+ * Copyright © 2015-2018 Budgie Desktop Developers
  * 
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/raven/notifications_view.vala
+++ b/src/raven/notifications_view.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  * 
- * Copyright © 2015-2017 Budgie Desktop Developers
+ * Copyright © 2015-2018 Budgie Desktop Developers
  * Copyright 2014 Josh Klar <j@iv597.com> (original Budgie work, prior to Budgie 10)
  * 
  * This program is free software; you can redistribute it and/or modify

--- a/src/raven/powerstrip.vala
+++ b/src/raven/powerstrip.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  * 
- * Copyright © 2015-2017 Budgie Desktop Developers
+ * Copyright © 2015-2018 Budgie Desktop Developers
  * 
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/raven/raven.vala
+++ b/src/raven/raven.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2015-2017 Budgie Desktop Developers
+ * Copyright © 2015-2018 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -33,11 +33,12 @@ public class RavenIface
     }
 
     public bool is_expanded {
-        public set {
-            parent.set_expanded(value);
-        }
         public get {
             return parent.get_expanded();
+        }
+
+        public set {
+            parent.set_expanded(value);
         }
     }
 

--- a/src/raven/sound.vala
+++ b/src/raven/sound.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  * 
- * Copyright © 2015-2017 Budgie Desktop Developers
+ * Copyright © 2015-2018 Budgie Desktop Developers
  * 
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -9,406 +9,457 @@
  * (at your option) any later version.
  */
 
-public class SoundWidget : Gtk.Box
-{
+namespace Budgie {
 
-    private Gtk.Scale? scale = null;
-    private ulong scale_id = 0;
+    public class SoundWidget : Gtk.Box {
 
-    private Gvc.MixerControl? mixer = null;
+        /**
+         * Logic and Mixer variables
+         */
+        private const string MAX_KEY = "allow-volume-above-100-percent";
+        private ulong scale_id = 0;
+        private Gvc.MixerControl mixer = null;
+        private HashTable<uint,Budgie.AppSoundControl?> apps;
+        private HashTable<string,string?> derpers;
+        private HashTable<uint,Gtk.RadioButton?> devices;
+        private ulong primary_notify_id = 0;
+        private Gvc.MixerStream? primary_stream = null;
+        private Settings settings = null;
+        private string widget_type = "";
 
-    private Gtk.Switch? output_switch = null;
-    private ulong output_switch_id = 0;
-    private Gtk.Box? output_box = null;
-    private Gtk.RadioButton? output_leader = null;
-    private HashTable<uint,Gtk.RadioButton?> outputs;
-    private Gvc.MixerStream? output_stream = null;
-    private ulong output_notify_id = 0;
+        /**
+         * Widgets
+         */
+        private Budgie.HeaderWidget? header = null;
+        private Gtk.Box? apps_area = null;
+        private Gtk.Box? apps_listbox = null;
+        private Gtk.Revealer? apps_list_revealer = null;
+        private Gtk.Box? devices_area = null;
+        private StartListening? listening_box = null;
+        private Gtk.Revealer? listening_box_revealer = null;
+        private Gtk.Box? main_layout = null;
+        private Gtk.RadioButton? device_leader = null;
+        private Gtk.Stack? widget_area = null;
+        private Gtk.StackSwitcher? widget_area_switch = null;
+        private Gtk.Scale? volume_slider = null;
 
-    private Gtk.Switch? input_switch = null;
-    private ulong input_switch_id = 0;
-    private Gtk.Box? input_box = null;
-    private Gtk.RadioButton? input_leader = null;
-    private HashTable<uint,Gtk.RadioButton?> inputs;
-    private Gvc.MixerStream? input_stream = null;
-    private ulong input_notify_id = 0;
+        public SoundWidget(string c_widget_type) {
+            Object(orientation: Gtk.Orientation.VERTICAL);
+            get_style_context().add_class("audio-widget");
+            widget_type = c_widget_type;
 
-    private Budgie.HeaderWidget? header = null;
+            /**
+             * Shared  Logic
+             */
+            mixer = new Gvc.MixerControl("Budgie Volume Control");
 
-    public SoundWidget()
-    {
-        Object(orientation: Gtk.Orientation.VERTICAL);
+            derpers = new HashTable<string,string?>(str_hash, str_equal); // Create our GVC Stream app derpers
+            derpers.insert("Vivaldi", "vivaldi"); // Vivaldi
+            derpers.insert("Vivaldi Snapshot", "vivaldi-snapshot"); // Vivaldi Snapshot
+            devices = new HashTable<uint,Gtk.RadioButton?>(direct_hash,direct_equal);
 
-        get_style_context().add_class("audio-widget");
+            /**
+             * Shared Construction
+             */
+            devices_area = new Gtk.Box(Gtk.Orientation.VERTICAL, 10);
+            main_layout = new Gtk.Box(Gtk.Orientation.VERTICAL, 0);
+            volume_slider = new Gtk.Scale.with_range(Gtk.Orientation.HORIZONTAL, 0, 100, 10);
+            volume_slider.set_draw_value(false);
+            volume_slider.value_changed.connect(on_scale_change);
 
-        /* TODO: Fix icon */
-        scale = new Gtk.Scale.with_range(Gtk.Orientation.HORIZONTAL, 0, 100, 10);
-        scale.set_draw_value(false);
-        scale.value_changed.connect(on_output_scale_change);
-        header = new Budgie.HeaderWidget("", "audio-volume-muted-symbolic", false, scale);
+            /**
+             * Type-Specific Logic and Construction
+             */
+            if (widget_type == "input") { // Input
+                mixer.default_source_changed.connect(on_device_changed);
+                mixer.input_added.connect(on_device_added);
+                mixer.input_removed.connect(on_device_removed);
 
-        var expander = new Budgie.RavenExpander(header);
-        pack_start(expander, false, false);
+                /**
+                 * Create our containers
+                 */
+                header = new Budgie.HeaderWidget("", "microphone-sensitivity-muted-symbolic", false, volume_slider);
+                main_layout.pack_start(devices_area, false, false, 0); // Add devices directly to layout
+                devices_area.margin_top = 10;
+                devices_area.margin_bottom = 10;
+            } else { // Output
+                settings = new Settings("org.gnome.desktop.sound");
+                apps = new HashTable<uint,Budgie.AppSoundControl?>(direct_hash,direct_equal);
 
-        var ebox = new Gtk.EventBox();
-        ebox.get_style_context().add_class("raven-background");
-        expander.add(ebox);
+                mixer.default_sink_changed.connect(on_device_changed);
+                mixer.output_added.connect(on_device_added);
+                mixer.output_removed.connect(on_device_removed);
+                mixer.state_changed.connect(on_state_changed);
+                mixer.stream_added.connect(on_stream_added);
+                mixer.stream_removed.connect(on_stream_removed);
+                settings.changed[MAX_KEY].connect(on_volume_safety_changed);
 
-        outputs = new HashTable<uint,Gtk.RadioButton?>(direct_hash,direct_equal);
-        inputs = new HashTable<uint,Gtk.RadioButton?>(direct_hash,direct_equal);
-        mixer = new Gvc.MixerControl("Budgie Volume Control");
-        mixer.state_changed.connect(on_state_changed);
-        mixer.output_added.connect(on_output_added);
-        mixer.output_removed.connect(on_output_removed);
-        mixer.input_added.connect(on_input_added);
-        mixer.input_removed.connect(on_input_removed);
-        mixer.default_sink_changed.connect(on_sink_changed);
-        mixer.default_source_changed.connect(on_source_changed);
+                /**
+                 * Create our designated areas, our stack, and switcher
+                 * Proceed to add those items to our main_layout
+                 */
+                apps_area = new Gtk.Box(Gtk.Orientation.VERTICAL, 0);
+                apps_listbox = new Gtk.Box(Gtk.Orientation.VERTICAL, 10);
 
-        var main_layout = new Gtk.Box(Gtk.Orientation.VERTICAL, 0);
-        main_layout.margin_top = 6;
-        main_layout.margin_bottom = 6;
-        main_layout.margin_start = 12;
-        main_layout.margin_end = 12;
+                apps_list_revealer = new Gtk.Revealer();
+                apps_list_revealer.set_transition_duration(250);
+                apps_list_revealer.set_transition_type(Gtk.RevealerTransitionType.SLIDE_UP);
+                apps_list_revealer.add(apps_listbox);
 
-        ebox.add(main_layout);
+                listening_box_revealer = new Gtk.Revealer();
+                listening_box_revealer.set_transition_duration(250);
+                listening_box_revealer.set_transition_type(Gtk.RevealerTransitionType.SLIDE_DOWN);
+                listening_box = new StartListening(); // Create our start listening box
+                listening_box_revealer.add(listening_box);
 
-        /* Output row */
-        var row = new Gtk.Box(Gtk.Orientation.HORIZONTAL, 0);
-        var label = new Gtk.Label(_("Output"));
-        label.get_style_context().add_class("heading");
-        row.pack_start(label, true, true, 0);
-        label.halign = Gtk.Align.START;
+                apps_area.pack_start(listening_box_revealer, true, true, 0);
+                apps_area.pack_end(apps_list_revealer, true, true, 0);
 
-        output_switch = new Gtk.Switch();
-        output_switch.active = false;
-        output_switch_id = output_switch.notify["active"].connect(on_output_mute_changed);
+                widget_area = new Gtk.Stack();
+                widget_area.margin_top = 10;
+                widget_area.margin_bottom = 10;
+                widget_area.set_transition_duration(125); // 125ms
+                widget_area.set_transition_type(Gtk.StackTransitionType.SLIDE_LEFT_RIGHT);
 
-        row.pack_end(output_switch, false, false, 0);
-        main_layout.pack_start(row, false, false, 0);
-        output_box = new Gtk.Box(Gtk.Orientation.VERTICAL, 0);
-        main_layout.pack_start(output_box, false, false, 0);
-        output_box.margin_bottom = 6;
+                widget_area.add_titled(apps_area, "apps", _("Apps"));
+                widget_area.add_titled(devices_area, "devices", _("Devices"));
 
-        /* Input row */
-        row = new Gtk.Box(Gtk.Orientation.HORIZONTAL, 0);
-        label = new Gtk.Label(_("Input"));
-        label.get_style_context().add_class("heading");
-        row.pack_start(label, true, true, 0);
-        label.halign = Gtk.Align.START;
+                widget_area_switch = new Gtk.StackSwitcher();
+                widget_area_switch.set_stack(widget_area);
+                widget_area_switch.set_homogeneous(true);
 
-        input_switch = new Gtk.Switch();
-        input_switch.active = false;
-        input_switch_id = input_switch.notify["active"].connect(on_input_mute_changed);
+                header = new Budgie.HeaderWidget("", "audio-volume-muted-symbolic", false, volume_slider);
+                main_layout.pack_start(widget_area, false, false, 0);
+                main_layout.pack_start(widget_area_switch, true, false, 0);
 
-        row.pack_end(input_switch, false, false, 0);
-        main_layout.pack_start(row, false, false, 0);
-        input_box = new Gtk.Box(Gtk.Orientation.VERTICAL, 0);
-        main_layout.pack_start(input_box, false, false, 0);
-        input_box.margin_bottom = 6;
+                listening_box_revealer.set_reveal_child(false); // Don't initially show
+                apps_list_revealer.set_reveal_child(false); // Don't initially show
+            }
 
-        expander.expanded = true;
+            mixer.open();
 
-        mixer.open();
-    }
+            /**
+             * Widget Expansion
+             */
 
-    /**
-     * New volume from our scale
-     */
-    void on_output_scale_change()
-    {
-        if (output_stream == null) {
-            return;
-        }
-        if (output_stream.set_volume((uint32)scale.get_value())) {
-            Gvc.push_volume(output_stream);
-        }
-    }
+            var expander = new Budgie.RavenExpander(header);
+            expander.expanded = (widget_type != "input");
 
-    /**
-     * Allow users to mute
-     */
-    void on_output_mute_changed()
-    {
-        if (output_stream == null) {
-            return;
-        }
-        output_stream.change_is_muted(!output_switch.active);
-    }
+            pack_start(expander, true, true);
 
-    /**
-     * Allow users to mute mic
-     */
-    void on_input_mute_changed()
-    {
-        if (input_stream == null) {
-            return;
-        }
-        input_stream.change_is_muted(!input_switch.active);
-    }
+            var ebox = new Gtk.EventBox();
+            ebox.get_style_context().add_class("raven-background");
+            expander.add(ebox);
+            ebox.add(main_layout);
 
-    /* Microphone changed */
-    void on_source_changed(uint id)
-    {
-        var stream = mixer.get_default_source();
-        if (stream == this.input_stream) {
-            return;
-        }
-        {
-            var device = mixer.lookup_device_from_stream(stream);
-            var did = device.get_id();
-            var check = inputs.lookup(did);
+            show_all();
 
-            if (check != null) {
-                SignalHandler.block_by_func((void*)check, (void*)on_input_selected, this);
-                check.active = true;
-                SignalHandler.unblock_by_func((void*)check, (void*)on_input_selected, this);
+            if (widget_type == "output") {
+                toggle_start_listening();
             }
         }
 
-        if (this.input_stream != null) {
-            this.input_stream.disconnect(this.input_notify_id);
-            input_notify_id = 0;
-        }
-        input_notify_id = stream.notify.connect((n,p)=> {
-            if (p.name == "is-muted") {
-                update_input();
+        /**
+         * on_device_added will handle when an input or output device has been added
+         */
+        private void on_device_added(uint id) {
+            if (devices.contains(id)) { // If we already have this device
+                return;
             }
-        });
 
-        this.input_stream = stream;
+            var device = (widget_type == "input") ? this.mixer.lookup_input_id(id) : this.mixer.lookup_output_id(id);
 
-        update_input();
-    }
+            if (device == null) {
+                return;
+            }
 
-    /** Update mute status on input stream */
-    void update_input()
-    {
-        if (this.input_stream == null) {
-            return;
+            if (device.card == null) {
+                return;
+            }
+
+            var card = device.card as Gvc.MixerCard;
+            var check = new Gtk.RadioButton.with_label_from_widget(this.device_leader, "%s - %s".printf(device.description, card.name));
+            (check.get_child() as Gtk.Label).set_ellipsize(Pango.EllipsizeMode.END);
+            (check.get_child() as Gtk.Label).max_width_chars = 30;
+            check.set_data("device_id", id);
+            check.toggled.connect(on_device_selected);
+            devices_area.pack_start(check, false, false, 0);
+            check.show_all();
+
+            if (this.device_leader == null) {
+                this.device_leader = check;
+            }
+
+            devices.insert(id, check);
         }
 
-        if (input_switch_id > 0) {
-            SignalHandler.block(input_switch, input_switch_id);
-            input_switch.active = !input_stream.is_muted;
-            SignalHandler.unblock(input_switch, input_switch_id);
-        } else {
-            input_switch.active = !input_stream.is_muted;
+        /**
+         * on_device_changed will handle when a Gvc.MixerUIDevice has been added
+         */
+        private void on_device_changed(uint id) {
+            Gvc.MixerStream stream = (widget_type == "input") ? mixer.get_default_source() : mixer.get_default_sink(); // Set default_stream to the respective source or sink
+
+            if (stream == this.primary_stream) { // Didn't really change
+                return;
+            }
+
+            {
+                var device = mixer.lookup_device_from_stream(stream);
+                var did = device.get_id();
+                var check = devices.lookup(did);
+
+                if (check != null) {
+                    SignalHandler.block_by_func((void*)check, (void*)on_device_selected, this);
+                    check.active = true;
+                    SignalHandler.unblock_by_func((void*)check, (void*)on_device_selected, this);
+                }
+            }
+
+            if (this.primary_stream != null) {
+                this.primary_stream.disconnect(this.primary_notify_id);
+                primary_notify_id = 0;
+            }
+
+            primary_notify_id = stream.notify.connect((n,p)=> {
+                if (p.name == "volume" || p.name == "is-muted") {
+                    update_volume();
+                }
+            });
+
+            this.primary_stream = stream;
+            update_volume();
         }
-    }
 
-    /* Somewhere new for where to put sound to */
-    void on_sink_changed(uint id)
-    {
-        var stream = mixer.get_default_sink();
-        if (stream == this.output_stream) {
-            return;
+        /**
+         * on_device_removed will handle when a Gvc.MixerUIDevice has been removed
+         */
+        private void on_device_removed(uint id) {
+            Gtk.RadioButton? btn = devices.lookup(id);
+
+            if (btn == null) {
+                warning("Removing id we don\'t know about: %u", id);
+                return;
+            }
+
+            devices.steal(id);
+            btn.destroy();
         }
 
-        {
-            var device = mixer.lookup_device_from_stream(stream);
-            var did = device.get_id();
-            var check = outputs.lookup(did);
+        /**
+         * on_device_selected will handle when a checkbox related to an input or output device is selected
+         */
+        private void on_device_selected(Gtk.ToggleButton? btn) {
+            if (!btn.get_active()) {
+                return;
+            }
 
-            if (check != null) {
-                SignalHandler.block_by_func((void*)check, (void*)on_output_selected, this);
-                check.active = true;
-                SignalHandler.unblock_by_func((void*)check, (void*)on_output_selected, this);
+            uint id = btn.get_data("device_id");
+            var device = (widget_type == "input") ? mixer.lookup_input_id(id) : mixer.lookup_output_id(id);
+
+            if (device != null) {
+                if (widget_type == "input") { // Input
+                    mixer.change_input(device);
+                } else { // Output
+                    mixer.change_output(device);
+                }
             }
         }
 
-        if (this.output_stream != null) {
-            this.output_stream.disconnect(this.output_notify_id);
-            output_notify_id = 0;
-        }
-        output_notify_id = stream.notify.connect((n,p)=> {
-            if (p.name == "volume" || p.name == "is-muted") {
-                update_volume();
+        /**
+         * When our volume slider has changed
+         */
+        private void on_scale_change() {
+            if (primary_stream == null) {
+                return;
             }
-        });
 
-        this.output_stream = stream;
-
-        update_volume();
-    }
-
-    void update_volume()
-    {
-        if (output_switch_id > 0) {
-            SignalHandler.block(output_switch, output_switch_id);
-            output_switch.active = !output_stream.is_muted;
-            SignalHandler.unblock(output_switch, output_switch_id);
-        } else {
-            output_switch.active = !output_stream.is_muted;
-        }
-
-        var vol_norm = mixer.get_vol_max_norm();
-        var vol = output_stream.get_volume();
-
-        /* Same maths as computed by volume.js in gnome-shell, carried over
-         * from C->Vala port of budgie-panel */
-        int n = (int) Math.floor(3*vol/vol_norm)+1;
-        string image_name;
-
-        // Work out an icon
-        if (output_stream.get_is_muted() || vol <= 0) {
-            image_name = "audio-volume-muted-symbolic";
-        } else {
-            switch (n) {
-                case 1:
-                    image_name = "audio-volume-low-symbolic";
-                    break;
-                case 2:
-                    image_name = "audio-volume-medium-symbolic";
-                    break;
-                default:
-                    image_name = "audio-volume-high-symbolic";
-                    break;
+            if (primary_stream.set_volume((uint32)volume_slider.get_value())) {
+                Gvc.push_volume(primary_stream);
             }
         }
-        header.icon_name = image_name;
-        var vol_max = mixer.get_vol_max_norm();
 
-        /* Each scroll increments by 5%, much better than units..*/
-        var step_size = vol_max / 20;
-        if (scale_id > 0) {
-            SignalHandler.block(scale, scale_id);
+        /**
+         * on_state_changed will handle when the state of our Mixer or its streams have changed
+         */
+        private void on_state_changed(uint id) {
+            var stream = mixer.lookup_stream_id(id);
+
+            if ((stream != null) && (stream.get_card_index() == -1)) { // If this is a stream (and not a card)
+                if (apps.contains(id)) { // If our apps contains this stream
+                    Budgie.AppSoundControl? control = apps.lookup(id);
+
+                    if (control != null) {
+                        if (stream.is_running()) { // If running
+                            control.refresh(); // Update our control
+                        } else { // If not running
+                            control.destroy();
+                            apps.steal(id);
+                        }
+                    }
+
+                    toggle_start_listening();
+                }
+            }
         }
-        scale.set_range(0, vol_max);
-        scale.set_value(vol);
-        scale.set_increments(step_size, step_size);
-        if (scale_id > 0) {
-            SignalHandler.unblock(scale, scale_id);
+
+        /**
+         * on_stream_added will handle when a stream (like an application) has been added
+         */
+        private void on_stream_added(uint id) {
+            Gvc.MixerStream stream = mixer.lookup_stream_id(id); // Get our stream
+
+            if ((stream != null) && (stream.get_card_index() == -1)) { // If this isn't a card
+                string name = stream.get_name();
+                string icon = stream.get_icon_name();
+
+                if (name == null) { // If this does not have a stream name (unlike bell-window-system, for example)
+                    return;
+                }
+
+                if (stream.is_event_stream) { // If this is an event stream, such as volume change sounds
+                    return;
+                }
+
+                if (stream.get_volume() == 100) {  // If volume doesn't match with mixer volume
+                    return;
+                }
+
+                if ((icon != "") && icon.contains("audio-input-")) { // If this is a microphone (for instances when WebRTC engine returns as input)
+                    return;
+                }
+
+                if (name == "System Sounds") { // If this is System Sounds
+                    return;
+                }
+
+                Gvc.MixerUIDevice device = mixer.lookup_device_from_stream(stream); // Get the associated device for this
+
+                if (device != null && !device.is_output()) { // If this is an input device
+                    return;
+                }
+
+                if (derpers.contains(name)) { // If our Gvc Stream derpers contains this application
+                    icon = derpers.get(name); // Use its designated icon instead
+                }
+
+                Budgie.AppSoundControl control = new Budgie.AppSoundControl(mixer, primary_stream, stream, icon); // Pass our Mixer, Stream, and correct Icon
+
+                if (control != null) {
+                    apps_listbox.pack_end(control); // Add our control
+                    apps.insert(id, control); // Add to apps
+                    apps_listbox.show_all();
+                    toggle_start_listening();
+                }
+            }
+        }
+
+        /**
+         * on_stream_removed will handle when a stream (like an application) has been removed
+         */
+        private void on_stream_removed(uint id) {
+            if (apps.contains(id)) { // If this stream exists in apps
+                Budgie.AppSoundControl control = apps.lookup(id);
+
+                if (control != null) { // If this control exists
+                    control.destroy(); // Remove the control
+                }
+
+                apps.steal(id); // Remove the apps
+                toggle_start_listening();
+            }
+        }
+
+        /**
+         * on_volume_safety_changed will listen to changes to our above 100 percent key
+         * If the volume is allowed to go over 100%, we'll update the slider range. Otherwise, we'll change or keep it at 100%
+         */
+        private void on_volume_safety_changed() {
+            bool allow_higher_than_max = settings.get_boolean(MAX_KEY);
+            var current_volume = volume_slider.get_value();
+            var vol_max = mixer.get_vol_max_norm();
+            var vol_max_above = mixer.get_vol_max_amplified();
+            var step_size = (allow_higher_than_max) ? vol_max_above / 20 : vol_max / 20;
+
+            int slider_start = 0;
+            int slider_end = 0;
+            volume_slider.get_slider_range(out slider_start, out slider_end);
+
+            if (allow_higher_than_max && (slider_end != vol_max_above)) { // If we're allowing higher than max and currently slider is not a max of 150
+                volume_slider.set_increments(step_size, step_size);
+                volume_slider.set_range(0, vol_max_above);
+                volume_slider.set_value(current_volume);
+            } else if (!allow_higher_than_max && (slider_end != vol_max)) { // If we're not allowing higher than max and slider is at max
+                volume_slider.set_increments(step_size, step_size);
+                volume_slider.set_range(0, vol_max);
+                volume_slider.set_value(current_volume);
+            }
+        }
+
+        /**
+         * toggle_start_listening will handle showing or hiding our Start Listening box if needed
+         */
+        private void toggle_start_listening() {
+            if (widget_type == "output") { // Output
+                bool apps_exist = (apps.length != 0);
+                listening_box_revealer.set_reveal_child(!apps_exist); // Show if no apps, hide if apps
+                apps_list_revealer.set_reveal_child(apps_exist); // Show if apps, hide if no apps
+            }
+        }
+
+        /**
+         * update_volume will handle updating our volume slider and output header during device change
+         */
+        private void update_volume() {
+            var vol = primary_stream.get_volume();
+            var vol_max = mixer.get_vol_max_norm();
+
+            if (settings.get_boolean(MAX_KEY)) { // Allowing max
+                vol_max = mixer.get_vol_max_amplified();
+            }
+
+            /* Same maths as computed by volume.js in gnome-shell, carried over
+            * from C->Vala port of budgie-panel */
+            int n = (int) Math.floor(3*vol/vol_max)+1;
+            string image_name;
+
+            // Work out an icon
+            string icon_prefix = (widget_type == "input") ? "microphone-sensitivity-" : "audio-volume-";
+
+            if (primary_stream.get_is_muted() || vol <= 0) {
+                image_name = "muted-symbolic";
+            } else {
+                switch (n) {
+                    case 1:
+                        image_name = "low-symbolic";
+                        break;
+                    case 2:
+                        image_name = "medium-symbolic";
+                        break;
+                    default:
+                        image_name = "high-symbolic";
+                        break;
+                }
+            }
+
+            header.icon_name = icon_prefix + image_name;
+
+            /* Each scroll increments by 5%, much better than units..*/
+            var step_size = vol_max / 20;
+
+            if (scale_id > 0) {
+                SignalHandler.block(volume_slider, scale_id);
+            }
+
+            volume_slider.set_increments(step_size, step_size);
+            volume_slider.set_range(0, vol_max);
+            volume_slider.set_value(vol);
+
+            if (scale_id > 0) {
+                SignalHandler.unblock(volume_slider, scale_id);
+            }
         }
     }
-
-    void on_output_selected(Gtk.ToggleButton? btn)
-    {
-        if (!btn.get_active()) {
-            return;
-        }
-        uint id = btn.get_data("output_id");
-        var device = mixer.lookup_output_id(id);
-        if (device == null) {
-            warning("Output selected does not exist! %u", id);
-            return;
-        }
-        mixer.change_output(device);
-    }
-
-    void on_input_selected(Gtk.ToggleButton? btn)
-    {
-        if (!btn.get_active()) {
-            return;
-        }
-        uint id = btn.get_data("input_id");
-        var device = mixer.lookup_input_id(id);
-        if (device == null) {
-            warning("Input selected does not exist! %u", id);
-            return;
-        }
-        mixer.change_input(device);
-    }
-
-    /* New available output */
-    void on_output_added(uint id)
-    {
-        if (outputs.contains(id)) {
-            return;
-        }
-        var device = this.mixer.lookup_output_id(id);
-
-        if (device.card == null) {
-            return;
-        }
-
-        var card = device.card as Gvc.MixerCard;
-        var check = new Gtk.RadioButton.with_label_from_widget(this.output_leader, "%s - %s".printf(device.description, card.name));
-        (check.get_child() as Gtk.Label).set_ellipsize(Pango.EllipsizeMode.END);
-        (check.get_child() as Gtk.Label).max_width_chars = 30;
-        check.set_data("output_id", id);
-        check.toggled.connect(on_output_selected);
-        output_box.pack_start(check, false, false, 0);
-        check.show_all();
-
-        if (this.output_leader == null) {
-            this.output_leader = check;
-            check.margin_top = 3;
-        }
-
-        outputs.insert(id, check);
-    }
-
-    /* New available input */
-    void on_input_added(uint id)
-    {
-        if (inputs.contains(id)) {
-            return;
-        }
-        var device = this.mixer.lookup_input_id(id);
-
-        if (device.card == null) {
-            return;
-        }
-
-        var card = device.card as Gvc.MixerCard;
-        var check = new Gtk.RadioButton.with_label_from_widget(this.input_leader, "%s - %s".printf(device.description, card.name));
-        (check.get_child() as Gtk.Label).set_ellipsize(Pango.EllipsizeMode.END);
-        (check.get_child() as Gtk.Label).max_width_chars = 30;
-        check.set_data("input_id", id);
-        check.toggled.connect(on_input_selected);
-        input_box.pack_start(check, false, false, 0);
-        check.show_all();
-
-        if (this.input_leader == null) {
-            this.input_leader = check;
-            check.margin_top = 3;
-        }
-
-        inputs.insert(id, check);
-    }
-
-    void on_output_removed(uint id)
-    {
-        Gtk.RadioButton? btn = outputs.lookup(id);
-        if (btn == null) {
-            warning("Removing id we don\'t know about: %u", id);
-            return;
-        }
-        outputs.steal(id);
-        btn.destroy();
-    }
-
-    void on_input_removed(uint id)
-    {
-        Gtk.RadioButton? btn = inputs.lookup(id);
-        if (btn == null) {
-            warning("Removing id we don\'t know about: %u", id);
-            return;
-        }
-        inputs.steal(id);
-        btn.destroy();
-    }
-
-    /* Update defaults, not yet implemented */
-    void update_mixers()
-    {
-
-    }
-
-    void on_state_changed(uint state)
-    {
-        switch (state) {
-            case Gvc.MixerControlState.READY:
-                /* We ready. */
-                update_mixers();
-                break;
-            default:
-                break;
-        }
-    }
-
-} // End class
+}
 
 /*
  * Editor modelines  -  https://www.wireshark.org/tools/modelines.html

--- a/src/raven/start_listening.vala
+++ b/src/raven/start_listening.vala
@@ -1,0 +1,58 @@
+/*
+ * This file is part of budgie-desktop
+ * 
+ * Copyright © 2015-2018 Budgie Desktop Developers
+ * 
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ */
+
+namespace Budgie {
+    public class StartListening : Gtk.Box {
+        private AppInfo? music_app = null; // Our current default music player that handles audio/ogg
+        private bool has_music_player; // Private bool of whether or not we have a music player installed
+        private Gtk.Button start_listening; // Our button to start listening to music
+
+        public StartListening() {
+            Object(orientation: Gtk.Orientation.VERTICAL, margin: 10);
+            var label = new Gtk.Label("<big>%s</big>".printf(_("No apps are currently playing audio.")));
+            label.halign = Gtk.Align.CENTER;
+            label.use_markup = true;
+            label.valign = Gtk.Align.CENTER;
+            start_listening = new Gtk.Button.with_label(_("Play some music"));
+            pack_start(label, true, true, 10);
+            pack_start(start_listening, false, false, 0);
+
+            var monitor = AppInfoMonitor.get(); // Get our AppInfoMonitor, which monitors the app info database for changes
+            monitor.changed.connect(check_music_support); // Recheck music support
+
+            start_listening.clicked.connect(launch_music_player);
+
+            check_music_support(); // Do our initial check
+        }
+
+        /*
+        * check_music_support will check if we have an application that supports vorbis.
+        * We're checking for vorbis since it's more likely the end user has open source vorbis support than alternative codecs like MP3
+        */
+        public void check_music_support() {
+            music_app = AppInfo.get_default_for_type("audio/vorbis", false);
+            has_music_player = (music_app != null);
+            start_listening.set_visible(has_music_player); // Set the visibility of the button based on if we have a music player
+        }
+
+        public void launch_music_player() {
+            if (music_app == null) {
+                return;
+            }
+
+            try {
+                music_app.launch(null, null);
+            } catch (Error e) {
+                warning("Unable to launch %s: %s", music_app.get_name(), e.message);
+            }
+        }
+    }
+}

--- a/src/rundialog/RunDialog.vala
+++ b/src/rundialog/RunDialog.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  * 
- * Copyright © 2015-2017 Budgie Desktop Developers
+ * Copyright © 2015-2018 Budgie Desktop Developers
  * 
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/wm/background.vala
+++ b/src/wm/background.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  * 
- * Copyright © 2015-2017 Budgie Desktop Developers
+ * Copyright © 2015-2018 Budgie Desktop Developers
  * 
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/wm/keyboard.vala
+++ b/src/wm/keyboard.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  * 
- * Copyright © 2015-2017 Budgie Desktop Developers
+ * Copyright © 2015-2018 Budgie Desktop Developers
  * Copyright (C) GNOME Shell Developers (Heavy inspiration, logic theft)
  * 
  * This program is free software; you can redistribute it and/or modify

--- a/src/wm/main.vala
+++ b/src/wm/main.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  * 
- * Copyright © 2015-2017 Budgie Desktop Developers
+ * Copyright © 2015-2018 Budgie Desktop Developers
  * 
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/wm/shim.vala
+++ b/src/wm/shim.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  * 
- * Copyright © 2015-2017 Budgie Desktop Developers
+ * Copyright © 2015-2018 Budgie Desktop Developers
  * 
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/wm/wm.vala
+++ b/src/wm/wm.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2015-2017 Budgie Desktop Developers
+ * Copyright © 2015-2018 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
This commit implements the brand new sound output and input widgets, where the Sound Output Widget provides per-app volume control, global control, and output device selection. The Sound Input Widget provides device control as well as microphone volume control.

When no apps are playing audio, we'll prompt the user to start listening to some music (checking for audio/vorbis support). When apps are playing, they appear in a list of AppSoundControl widgets, where we attempt to find the "best" or most relevant application icon from the icon theme, not necessarily the one Gvc may provide (in rare instances). We'll also attempt to filter out apps like System Sounds, WebRTC Engine (Discord), event-based volume change sounds, and more.

This commit additionally makes tweaks to the RavenExpander and its relevant components, to fix issues where it was always assumed that each widget would default to be expanded and thus not properly change its state.

Another feature in this commit is the MprisGui now setting a class for the player or its desktop entry (such as "spotify"), which should hopefully improve the level of customization for theme authors.

Updated all copyrights to 2015-2018.