### PR TITLE
Fix Sound Overdrive and add visual cue

### DIFF
--- a/src/panel/settings/settings_raven.vala
+++ b/src/panel/settings/settings_raven.vala
@@ -21,6 +21,7 @@ public class RavenPage : Budgie.SettingsPage {
     private Gtk.Switch? show_mic_input_widget;
     private Gtk.Switch? show_mpris_widget;
     private GLib.Settings raven_settings;
+    private GLib.Settings sound_settings;
 
     public RavenPage() {
         Object(group: SETTINGS_GROUP_APPEARANCE,
@@ -65,11 +66,13 @@ public class RavenPage : Budgie.SettingsPage {
         ));
 
         raven_settings = new GLib.Settings("com.solus-project.budgie-raven");
-        raven_settings.bind("allow-volume-overdrive", allow_volume_overdrive, "active", SettingsBindFlags.DEFAULT);
         raven_settings.bind("show-calendar-widget", show_calendar_widget, "active", SettingsBindFlags.DEFAULT);
         raven_settings.bind("show-sound-output-widget", show_sound_output_widget, "active", SettingsBindFlags.DEFAULT);
         raven_settings.bind("show-mic-input-widget", show_mic_input_widget, "active", SettingsBindFlags.DEFAULT);
         raven_settings.bind("show-mpris-widget", show_mpris_widget, "active", SettingsBindFlags.DEFAULT);
+
+        sound_settings = new GLib.Settings("org.gnome.desktop.sound");
+        sound_settings.bind("allow-volume-above-100-percent", allow_volume_overdrive, "active", SettingsBindFlags.DEFAULT);
     }
 }
 

--- a/src/raven/com.solus-project.budgie.raven.gschema.xml
+++ b/src/raven/com.solus-project.budgie.raven.gschema.xml
@@ -2,12 +2,6 @@
 <schemalist gettext-domain="budgie-desktop">
 
   <schema path="/com/solus-project/budgie-raven/" id="com.solus-project.budgie-raven">
-    <key type="b" name="allow-volume-overdrive">
-      <default>false</default>
-      <summary>Allow raising volume above 100%</summary>
-      <description>This setting overrides the one provided by org.gnome.desktop.sound.</description>
-    </key>
-
     <key type="b" name="show-calendar-widget">
       <default>true</default>
       <summary>Show the Calendar widget in Raven</summary>

--- a/src/raven/sound.vala
+++ b/src/raven/sound.vala
@@ -1,8 +1,8 @@
 /*
  * This file is part of budgie-desktop
- * 
+ *
  * Copyright © 2015-2018 Budgie Desktop Developers
- * 
+ *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
@@ -70,7 +70,7 @@ namespace Budgie {
             /**
              * Type-Specific Logic and Construction
              */
-            if (widget_type == "input") { // Input
+            if (widget_type == "input") { // Input 
                 mixer.default_source_changed.connect(on_device_changed);
                 mixer.input_added.connect(on_device_added);
                 mixer.input_removed.connect(on_device_removed);
@@ -383,6 +383,7 @@ namespace Budgie {
             int slider_start = 0;
             int slider_end = 0;
             volume_slider.get_slider_range(out slider_start, out slider_end);
+            volume_slider.add_mark(vol_max, Gtk.PositionType.BOTTOM, null);
 
             if (allow_higher_than_max && (slider_end != vol_max_above)) { // If we're allowing higher than max and currently slider is not a max of 150
                 volume_slider.set_increments(step_size, step_size);
@@ -392,6 +393,7 @@ namespace Budgie {
                 volume_slider.set_increments(step_size, step_size);
                 volume_slider.set_range(0, vol_max);
                 volume_slider.set_value(current_volume);
+                volume_slider.clear_marks();
             }
         }
 


### PR DESCRIPTION
The new sound overdrive from Budgie Settings doesn't really work, 
because it's modify unused gschema key by Raven and Gnome Control Panel. 
In the end, there's is no visual cue for normal maximum volume when 
audio overdrive was activated