### PR TITLE
Set ellipsize property on notifications

### DIFF
--- a/src/raven/ui/notification.ui
+++ b/src/raven/ui/notification.ui
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.19.0 -->
+<!-- Generated with glade 3.22.1 -->
 <interface>
   <requires lib="gtk+" version="3.12"/>
   <object class="GtkImage" id="image2">
@@ -80,6 +80,7 @@
                 <property name="label"> </property>
                 <property name="wrap">True</property>
                 <property name="wrap_mode">word-char</property>
+                <property name="ellipsize">end</property>
                 <property name="xalign">0</property>
                 <style>
                   <class name="notification-body"/>


### PR DESCRIPTION
With this change, pop-up notification bodies will be ellipsized if the text is longer than one line. The full body text can still be viewed in Raven's notification center.

Tested by running the `notify-send` command with a long text (700 characters).

Resolves #1267