### PR TITLE
Drop default value of non-automatic property

### DIFF
--- a/src/applets/icon-tasklist/Icon.vala
+++ b/src/applets/icon-tasklist/Icon.vala
@@ -20,8 +20,9 @@ public class Icon : Gtk.Image
     private int wait_cycle_counter = 0;
     private int attention_cycle_counter = 0;
 
-    private double bounce_amount = 0;
-    private double attention_amount = 0;
+    private double bounce_amount = 0.0;
+    private double attention_amount = 0.0;
+    private double opacity = 1.0;
 
     public double bounce {
         public set {
@@ -31,7 +32,6 @@ public class Icon : Gtk.Image
         public get {
             return bounce_amount;
         }
-        default = 0.0;
     }
 
     public double attention {
@@ -42,7 +42,6 @@ public class Icon : Gtk.Image
         public get {
             return attention_amount;
         }
-        default = 0.0;
     }
 
     public double icon_opacity {
@@ -56,7 +55,6 @@ public class Icon : Gtk.Image
         public get {
             return opacity;
         }
-        default = 1.0;
     }
 
     public Icon() {}

--- a/src/applets/status/PowerIndicator.vala
+++ b/src/applets/status/PowerIndicator.vala
@@ -30,7 +30,6 @@ public class BatteryIcon : Gtk.Box
         public get {
             return this.percent_label.visible;
         }
-        default = false;
     }
 
     public BatteryIcon(Up.Device battery) {

--- a/src/panel/panel.vala
+++ b/src/panel/panel.vala
@@ -120,7 +120,6 @@ public class Panel : Budgie.Toplevel
         public get {
             return render_scale;
         }
-        default = 0.0;
     }
 
     public bool activate_action(int remote_action)

--- a/src/raven/headerwidget.vala
+++ b/src/raven/headerwidget.vala
@@ -34,7 +34,6 @@ public class HeaderExpander : Gtk.Button
         public get {
             return this._expanded;
         }
-        default = false;
     }
 
     public HeaderExpander(HeaderWidget? owner)

--- a/src/raven/raven.vala
+++ b/src/raven/raven.vala
@@ -170,7 +170,6 @@ public class Raven : Gtk.Window
         public get {
             return this._screen_edge;
         }
-        default = Gtk.PositionType.RIGHT;
     }
 
     int our_width = 0;


### PR DESCRIPTION
Currently, I'm using Fedora Rawhide to test https://github.com/solus-project/budgie-desktop/pull/1523 but the build is failing. It has Vala 0.41.91 and something changed in it. Other project that faced similar issue is https://gitlab.gnome.org/GNOME/simple-scan/issues/47. I hope this PR can solve this issue.

```
../src/raven/raven.vala:150.5-150.39: error: Property `Budgie.Raven.screen_edge' with custom `get' accessor and/or `set' mutator cannot have `default' value
    public Gtk.PositionType screen_edge {                                                                                                                                
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                   
../src/raven/raven.vala:380.13-380.28: error: invalid left operand                                                                                                       
        if (this.screen_edge == Gtk.PositionType.RIGHT) {                                                             
            ^^^^^^^^^^^^^^^^                             
```