### PR TITLE
Update GVC submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "gvc"]
 	path = subprojects/gvc
-	url = https://git.gnome.org/browse/libgnome-volume-control
+	url = https://gitlab.gnome.org/GNOME/libgnome-volume-control.git


### PR DESCRIPTION
Based on upstream, now ALSA support is enabled by default in GVC's meson configuration. With this changed, ALSA should be added to our build dependencies.