### PR TITLE
Force raven widget show/hide to display contents correctly

### DIFF
--- a/src/raven/main_view.vala
+++ b/src/raven/main_view.vala
@@ -1,8 +1,8 @@
 /*
  * This file is part of budgie-desktop
- * 
+ *
  * Copyright © 2015-2018 Budgie Desktop Developers
- * 
+ *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
@@ -137,6 +137,10 @@ public class MainView : Gtk.Box
 
     public void set_clean()
     {
+        on_raven_settings_changed("show-calendar-widget");
+        on_raven_settings_changed("show-sound-output-widget");
+        on_raven_settings_changed("show-mic-input-widget");
+        on_raven_settings_changed("show-mpris-widget");
         main_stack.set_visible_child_name("applets");
     }
 }


### PR DESCRIPTION
On GTK+3.24 Ubuntu 18.10 - after a restart of the panel/logout login the raven widgets visibility changes back to their defaults - e.g. calendar widget always displays regardless if Raven Settings say to hide the widget.

This is because on raven.vala the MainView is set to "show" which forces all the widgets to be made visible - but there is nothing in MainView.vala to reset their visibility.

The set_clean method seems like a reasonable point here to force a visibility recalculation.