### PR TITLE
Fix some text escaping with certain applications

### DIFF
--- a/src/raven/notifications_view.vala
+++ b/src/raven/notifications_view.vala
@@ -41,14 +41,18 @@ public static string safe_markup_string(string inp)
     /* Explicit copy */
     string inp2 = "" + inp;
 
+    /* 
+     * is it already escaped?
+     * 
+     * &#39; is the ASCII code for a single quote
+     */
+    if (("&lt;" in inp2) || ("&gt;" in inp2) || ("&amp;" in inp2) || ("&nbsp;" in inp2) || ("&#39;" in inp2) || ("&apos;" in inp2) || ("&quot;" in inp2)) {
+        return inp2;
+    }
+
     /* is it markup? */
     if (!(("<" in inp2) && (">" in inp2))) {
         return Markup.escape_text(inp2);
-    }
-
-    /* is it already escaped? */
-    if (("&lt;" in inp2) || ("&gt;" in inp2) || ("&amp;" in inp2) || ("&nbsp;" in inp2)) {
-        return inp2;
     }
 
     /* Ensure it's now sane */

--- a/src/raven/notifications_view.vala
+++ b/src/raven/notifications_view.vala
@@ -25,6 +25,17 @@ public const string ROOT_KEY_SPAM_APPS = "spam-apps";
 /** Spam categories */
 public const string ROOT_KEY_SPAM_CATEGORIES = "spam-categories";
 
+/** Character escape strings */
+public const string[] ESCAPE_STRINGS = {
+    "&lt;", // less-than sign
+    "&gt;", // greater-than sign
+    "&amp;", // ampersand (&)
+    "&nbsp;", // non-breaking space
+    "&#39;", // ASCII single quote
+    "&apos;", // apostrophy
+    "&quot;" // double quote
+};
+
 public enum NotificationCloseReason {
     EXPIRED = 1,    /** The notification expired. */
     DISMISSED = 2,  /** The notification was dismissed by the user. */
@@ -43,11 +54,11 @@ public static string safe_markup_string(string inp)
 
     /* 
      * is it already escaped?
-     * 
-     * &#39; is the ASCII code for a single quote
      */
-    if (("&lt;" in inp2) || ("&gt;" in inp2) || ("&amp;" in inp2) || ("&nbsp;" in inp2) || ("&#39;" in inp2) || ("&apos;" in inp2) || ("&quot;" in inp2)) {
-        return inp2;
+    foreach (string str in ESCAPE_STRINGS) {
+        if (inp2.contains(str)) { // Already escaped
+            return inp2;
+        }
     }
 
     /* is it markup? */


### PR DESCRIPTION
Certain applications like HexChat and Discord print ASCII character codes in their notification texts, which then gets sent to the user without being replaced.

The check that determines if a string is markup must come after checking if the string is already escaped. Otherwise, these character codes don't get replaced and display as `&#39;`, `&amp;`, etc.

I suspect that this whole thing could be improved, but that might be more of a post-10.5 thing.

Here is a picture of the (now as expected) notifications:
![image](https://user-images.githubusercontent.com/5157277/49260634-78e72800-f40c-11e8-8ebf-1bde83395cca.png)
This was also tested using the `notify-send` command. Text from this command was never broken, and it remains unbroken.