### PR TITLE
Remove default property values for Vala 0.42 and beyond

### DIFF
--- a/src/applets/icon-tasklist/Icon.vala
+++ b/src/applets/icon-tasklist/Icon.vala
@@ -31,7 +31,9 @@ public class Icon : Gtk.Image
         public get {
             return bounce_amount;
         }
+#if !VALA_0_42
         default = 0.0;
+#endif
     }
 
     public double attention {
@@ -42,7 +44,9 @@ public class Icon : Gtk.Image
         public get {
             return attention_amount;
         }
+#if !VALA_0_42
         default = 0.0;
+#endif
     }
 
     public double icon_opacity {
@@ -56,7 +60,9 @@ public class Icon : Gtk.Image
         public get {
             return opacity;
         }
+#if !VALA_0_42
         default = 1.0;
+#endif
     }
 
     public Icon() {}

--- a/src/applets/icon-tasklist/IconButton.vala
+++ b/src/applets/icon-tasklist/IconButton.vala
@@ -388,7 +388,7 @@ public class IconButton : Gtk.ToggleButton
     }
 
     private Wnck.Window get_next_window()
-    {        
+    {
         if (class_group == null) {
             return this.window;
         }
@@ -669,7 +669,7 @@ public class IconButton : Gtk.ToggleButton
                     case Budgie.PanelPosition.RIGHT:
                         int to = 0;
                         if (counter == count-1) {
-                            to = y + height; 
+                            to = y + height;
                         } else {
                             to = previous_y+(height/count);
                         }
@@ -678,7 +678,7 @@ public class IconButton : Gtk.ToggleButton
                     default:
                         int to = 0;
                         if (counter == count-1) {
-                            to = x + width; 
+                            to = x + width;
                         } else {
                             to = previous_x+(width/count);
                         }

--- a/src/applets/spacer/SpacerApplet.vala
+++ b/src/applets/spacer/SpacerApplet.vala
@@ -1,8 +1,8 @@
 /*
  * This file is part of budgie-desktop
- * 
+ *
  * Copyright © 2015-2018 Budgie Desktop Developers
- * 
+ *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or

--- a/src/applets/status/PowerIndicator.vala
+++ b/src/applets/status/PowerIndicator.vala
@@ -30,7 +30,9 @@ public class BatteryIcon : Gtk.Box
         public get {
             return this.percent_label.visible;
         }
+#if !VALA_0_42
         default = false;
+#endif
     }
 
     public BatteryIcon(Up.Device battery) {
@@ -141,7 +143,7 @@ public class PowerIndicator : Gtk.Bin
 
     private HashTable<string,BatteryIcon?> devices;
 
-    public bool label_visible { set ; get ; default = false; }
+    public bool label_visible { set; get; default = false; }
     private Gtk.CheckButton check_percent;
     private Settings battery_settings;
 

--- a/src/panel/panel.vala
+++ b/src/panel/panel.vala
@@ -1,8 +1,8 @@
 /*
  * This file is part of budgie-desktop
- * 
+ *
  * Copyright © 2015-2018 Budgie Desktop Developers
- * 
+ *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
@@ -19,7 +19,7 @@ namespace Budgie
  */
 public class MainPanel : Gtk.Box
 {
- 
+
     public MainPanel()
     {
         Object(orientation: Gtk.Orientation.HORIZONTAL);
@@ -120,7 +120,9 @@ public class Panel : Budgie.Toplevel
         public get {
             return render_scale;
         }
+#if !VALA_0_42
         default = 0.0;
+#endif
     }
 
     public bool activate_action(int remote_action)

--- a/src/panel/settings/settings_item.vala
+++ b/src/panel/settings/settings_item.vala
@@ -1,8 +1,8 @@
 /*
  * This file is part of budgie-desktop
- * 
+ *
  * Copyright © 2015-2018 Budgie Desktop Developers
- * 
+ *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
@@ -17,7 +17,7 @@ public class SettingsItem : Gtk.Box {
     private Gtk.Label widget_label;
 
     /* Bindable for sorting */
-    public int display_weight { public set ; public get; default = 0 ; }
+    public int display_weight { public set; public get; default = 0; }
 
 
     public string icon_name { public get ; public set ; }

--- a/src/panel/settings/settings_page.vala
+++ b/src/panel/settings/settings_page.vala
@@ -1,8 +1,8 @@
 /*
  * This file is part of budgie-desktop
- * 
+ *
  * Copyright © 2015-2018 Budgie Desktop Developers
- * 
+ *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or

--- a/src/raven/headerwidget.vala
+++ b/src/raven/headerwidget.vala
@@ -1,8 +1,8 @@
 /*
  * This file is part of budgie-desktop
- * 
+ *
  * Copyright © 2015-2018 Budgie Desktop Developers
- * 
+ *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
@@ -34,7 +34,9 @@ public class HeaderExpander : Gtk.Button
         public get {
             return this._expanded;
         }
+    #if !VALA_0_42
         default = false;
+    #endif
     }
 
     public HeaderExpander(HeaderWidget? owner)

--- a/src/raven/raven.vala
+++ b/src/raven/raven.vala
@@ -106,7 +106,7 @@ public class RavenIface
         }
     }
 
-    
+
     public signal void NotificationsChanged();
 
     public uint GetNotificationCount() {
@@ -170,7 +170,9 @@ public class Raven : Gtk.Window
         public get {
             return this._screen_edge;
         }
+#if !VALA_0_42
         default = Gtk.PositionType.RIGHT;
+#endif
     }
 
     int our_width = 0;


### PR DESCRIPTION
Default values are forbidden when a property has custom getter and setter
methods on Vala 0.42.