### PR TITLE
Fix can't change window after show desktop

### DIFF
--- a/src/applets/show-desktop/ShowDesktopApplet.vala
+++ b/src/applets/show-desktop/ShowDesktopApplet.vala
@@ -76,10 +76,9 @@ public class ShowDesktopApplet : Budgie.Applet
     {
         var window = Wnck.Window.@get(xid);
 
-        if (window != null && window.is_minimized()) {
-            var utc_now = new DateTime.now_utc();
-            var now = (uint32) utc_now.to_unix();
-            window.unminimize(now);
+        if (window != null && window.is_minimized())
+        {
+            window.unminimize(Gtk.get_current_event_time());
         }
     }
 }


### PR DESCRIPTION
Because I set an invalid timestamp, sometime I can't change window
using the tasklist. Another bug is sometime the focus will jump around
between unminimized windows, still can't find the fix for that.