### PR TITLE
Allow tabswitcher to use any modifier

### DIFF
--- a/src/daemon/tabswitcher.vala
+++ b/src/daemon/tabswitcher.vala
@@ -326,7 +326,7 @@ public class TabSwitcher : Object
         mod_timeout = 0;
         Gdk.ModifierType modifier;
         Gdk.Display.get_default().get_default_seat().get_pointer().get_state(Gdk.get_default_root_window(), null, out modifier);
-        if ((modifier & Gdk.ModifierType.MOD1_MASK) == 0 && (modifier & Gdk.ModifierType.MOD4_MASK) == 0) {
+        if ((modifier & Gdk.ModifierType.MODIFIER_MASK) == 0) {
             switcher_window.hide();
             return false;
         }


### PR DESCRIPTION
The current tabswitcher is hardcoded for super or alt as the modifier. These are the common modifiers for it, but since you can override it with pretty much anything using gnome-control-center or dconf this is not a safe assumption.

This PR allows any modifier. Without it ctrl+tab for example is broken. It will cycle between the two most recent apps only.

A more "proper" solution might be to check for the dconf entry and only allow the actual modifiers defined there, but it's less straightforward and more confusing (how would you handle multiple modifiers in the combo?). Also, I'm assuming people release their modifiers after switching the app.

I have built and tested this and it works for any of the modifiers I tried (including alt, cmd and ctrl).