### PR TITLE
Remove redundant year in copyright notice

### DIFF
--- a/src/applets/icon-tasklist/Icon.vala
+++ b/src/applets/icon-tasklist/Icon.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2017-2018-2018 Budgie Desktop Developers
+ * Copyright © 2017-2018 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
Tiny fix for what was probably a search-and-replace error.