### PR TITLE
Fix IconTaskList buttons getting stuck in pressed state

### DIFF
--- a/src/applets/icon-tasklist/IconButton.vala
+++ b/src/applets/icon-tasklist/IconButton.vala
@@ -871,7 +871,6 @@ public class IconButton : Gtk.ToggleButton
                     this.window.unminimize(event.time);
                     this.window.activate(event.time);
                 }
-                return Gdk.EVENT_STOP;
             } else if (class_group != null) {
                 bool all_unminimized = true;
                 bool one_active = false;


### PR DESCRIPTION
When window grouping is disabled, left mouse release events were not being passed to the Gtk.ToggleButton, keeping it in a pressed state and causing CSS animation bugs.