### PR TITLE
Adjust panel size offsets for IconTaskList. Fixes #1401.

### DIFF
--- a/src/applets/icon-tasklist/IconTasklistApplet.vala
+++ b/src/applets/icon-tasklist/IconTasklistApplet.vala
@@ -556,9 +556,10 @@ public class IconTasklistApplet : Budgie.Applet
     {
         this.desktop_helper.icon_size = small_icon;
 
-        this.desktop_helper.panel_size = panel - 1;
         if (get_orientation() == Gtk.Orientation.HORIZONTAL) {
-            this.desktop_helper.panel_size = panel - 6;
+            this.desktop_helper.panel_size = panel - 5;
+        } else {
+            this.desktop_helper.panel_size = panel;
         }
 
         set_icons_size();


### PR DESCRIPTION
As indicated by GTK Inspector, IconButton is always 1px smaller than the surrounding ButtonWrapper along the short-axis of the panel.

The panel size offsets have been adjusted so that IconButton matches the size of ButtonWrapper.