### PR TITLE
Don't compare two different timers for animations. Fixes #1407, #1708.

### DIFF
--- a/src/applets/icon-tasklist/animation.vala
+++ b/src/applets/icon-tasklist/animation.vala
@@ -102,7 +102,7 @@ public class Animation : Object {
     public void start(AnimCompletionFunc? compl)
     {
         if (!no_reset) {
-            start_time = get_monotonic_time();
+            start_time = widget.get_frame_clock().get_frame_time();
         }
         this.compl = compl;
         can_anim = true;

--- a/src/lib/animation.vala
+++ b/src/lib/animation.vala
@@ -102,7 +102,7 @@ public class Animation : Object {
     public void start(AnimCompletionFunc? compl)
     {
         if (!no_reset) {
-            start_time = get_monotonic_time();
+            start_time = widget.get_frame_clock().get_frame_time();
         }
         this.compl = compl;
         can_anim = true;


### PR DESCRIPTION
The animation class used get_monotonic_time() for start time and Gdk.FrameClock for current time, resulting in degraded animations as the two timers drift apart.