### PR TITLE
Make "No apps are playing" less intrusive

### DIFF
--- a/src/raven/start_listening.vala
+++ b/src/raven/start_listening.vala
@@ -17,7 +17,7 @@ namespace Budgie {
 
         public StartListening() {
             Object(orientation: Gtk.Orientation.VERTICAL, margin: 10);
-            var label = new Gtk.Label("<big>%s</big>".printf(_("No apps are currently playing audio.")));
+            var label = new Gtk.Label("<i>%s</i>".printf(_("No apps are currently playing audio.")));
             label.halign = Gtk.Align.CENTER;
             label.use_markup = true;
             label.valign = Gtk.Align.CENTER;


### PR DESCRIPTION
With <big> that label takes more attention than it should, whereas with an <i> it catches the user's attention without being bigger than anything on that panel.