### PR TITLE
IconTaskList: Don't override GTK size allocation

### DIFF
--- a/src/applets/icon-tasklist/Icon.vala
+++ b/src/applets/icon-tasklist/Icon.vala
@@ -59,27 +59,13 @@ public class Icon : Gtk.Image
         default = 1.0;
     }
 
-    public Icon() {}
-
-    public override void size_allocate(Gtk.Allocation allocation) {
-        this.queue_resize();
-        Gtk.Allocation alloc;
-        this.get_parent().get_allocation(out alloc);
-        base.size_allocate(alloc);
+    public Icon() {
+        size_allocate.connect(this.on_size_allocate);
     }
 
-    public override void get_preferred_width(out int min, out int nat)
-    {
-        Gtk.Allocation alloc;
-        this.get_parent().get_allocation(out alloc);
-        min = nat = this.widget_width = alloc.width;
-    }
-
-    public override void get_preferred_height(out int min, out int nat)
-    {
-        Gtk.Allocation alloc;
-        this.get_parent().get_allocation(out alloc);
-        min = nat = this.widget_height = alloc.height;
+    protected void on_size_allocate(Gtk.Allocation allocation) {
+        this.widget_width = allocation.width;
+        this.widget_height = allocation.height;
     }
 
     public void animate_attention(Budgie.PanelPosition? position)

--- a/src/applets/icon-tasklist/IconButton.vala
+++ b/src/applets/icon-tasklist/IconButton.vala
@@ -161,6 +161,7 @@ public class IconButton : Gtk.ToggleButton
         st.add_class("launcher");
         this.relief = Gtk.ReliefStyle.NONE;
 
+        size_allocate.connect(this.on_size_allocate);
         launch_context.launched.connect(this.on_launched);
         launch_context.launch_failed.connect(this.on_launch_failed);
     }
@@ -759,9 +760,8 @@ public class IconButton : Gtk.ToggleButton
         return base.draw(cr);
     }
 
-    public override void size_allocate(Gtk.Allocation allocation) {
-        definite_allocation.x = allocation.x;
-        definite_allocation.y = allocation.y;
+    protected void on_size_allocate(Gtk.Allocation allocation) {
+        definite_allocation = allocation;
 
         base.size_allocate(definite_allocation);
 
@@ -833,24 +833,27 @@ public class IconButton : Gtk.ToggleButton
 
     public override void get_preferred_width(out int min, out int nat)
     {
-        /* Stop GTK from bitching */
-        int m, n;
-        base.get_preferred_width(out m, out n);
-
-        int width = this.desktop_helper.panel_size;
         if (this.desktop_helper.orientation == Gtk.Orientation.HORIZONTAL) {
-            width += 6;
+            min = nat = this.desktop_helper.panel_size;
+            return;
+        } else {
+            int m, n;
+            base.get_preferred_width(out m, out n);
+            min = m;
+            nat = n;
         }
-        min = nat = definite_allocation.width = width;
     }
 
     public override void get_preferred_height(out int min, out int nat)
     {
-        /* Stop GTK from bitching */
-        int m, n;
-        base.get_preferred_height(out m, out n);
-
-        min = nat = definite_allocation.height = this.desktop_helper.panel_size;
+        if (this.desktop_helper.orientation == Gtk.Orientation.VERTICAL) {
+            min = nat = this.desktop_helper.panel_size;
+        } else {
+            int m, n;
+            base.get_preferred_height(out m, out n);
+            min = m;
+            nat = n;
+        }
     }
 
     public override bool button_release_event(Gdk.EventButton event)

--- a/src/applets/icon-tasklist/IconTasklistApplet.vala
+++ b/src/applets/icon-tasklist/IconTasklistApplet.vala
@@ -555,13 +555,7 @@ public class IconTasklistApplet : Budgie.Applet
     public override void panel_size_changed(int panel, int icon, int small_icon)
     {
         this.desktop_helper.icon_size = small_icon;
-
-        if (get_orientation() == Gtk.Orientation.HORIZONTAL) {
-            this.desktop_helper.panel_size = panel - 5;
-        } else {
-            this.desktop_helper.panel_size = panel;
-        }
-
+        this.desktop_helper.panel_size = panel;
         set_icons_size();
     }
 


### PR DESCRIPTION
The IconTaskList should now respect the size allocation it is given.
Fixes #1737
Fixes #1401 (properly)