### PR TITLE
Polkit: Correctly handle the user dismissing the authentication dialog

### DIFF
--- a/vapi/polkit-agent-1.vapi
+++ b/vapi/polkit-agent-1.vapi
@@ -6,7 +6,7 @@ namespace PolkitAgent {
 	public abstract class Listener : GLib.Object {
 		[CCode (has_construct_function = false)]
 		protected Listener ();
-        public virtual async bool initiate_authentication(string action_id, string message, string icon_name, Polkit.Details details, string cookie, GLib.List<Polkit.Identity?>? identities, GLib.Cancellable cancellable);
+        public virtual async bool initiate_authentication(string action_id, string message, string icon_name, Polkit.Details details, string cookie, GLib.List<Polkit.Identity?>? identities, GLib.Cancellable cancellable) throws Polkit.Error;
         /*
         public virtual void initiate_authentication(string action_id, string message, string icon_name, Polkit.Details details, string cookie, GLib.List<Polkit.Identity?>? identities, GLib.Cancellable cancellable, GLib.AsyncReadyCallback @callback);
 		public virtual bool initiate_authentication_finish (GLib.AsyncResult res) throws GLib.Error;*/


### PR DESCRIPTION
Adapted from elementary/pantheon-agent-polkit#26:
* Throw Polkit.Error.CANCELLED when the user dismisses the dialog
* Listen for events in the Cancellable object instead of using it

Testing:
* `pkexec` -> click cancel on dialog -> pkexec exits as dismissed
* `pkexec` -> Ctrl-C in terminal -> authentication dialog closes

Fixes #1279