### PR TITLE
Prevent empty menu categories

### DIFF
--- a/src/applets/budgie-menu/BudgieMenuWindow.vala
+++ b/src/applets/budgie-menu/BudgieMenuWindow.vala
@@ -1,8 +1,8 @@
 /*
  * This file is part of budgie-desktop
- * 
+ *
  * Copyright © 2015-2019 Budgie Desktop Developers
- * 
+ *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
@@ -39,7 +39,7 @@ public class BudgieMenuWindow : Budgie.Popover
     /* Mapped id -> button */
     protected HashTable<string,MenuButton?> menu_buttons = null;
 
-    // The current group 
+    // The current group
     protected GMenu.TreeDirectory? group = null;
     protected bool compact_mode;
     protected bool headers_visible;
@@ -77,7 +77,7 @@ public class BudgieMenuWindow : Budgie.Popover
         }
         SignalHandler.disconnect_by_func(tree, (void*)refresh_tree, this);
         this.tree = null;
-        Idle.add(()=> { 
+        Idle.add(()=> {
             load_menus(null);
             content.invalidate_headers();
             content.invalidate_filter();
@@ -111,13 +111,13 @@ public class BudgieMenuWindow : Budgie.Popover
 
     /**
      * Load "menus" (.desktop's) recursively (ripped from our RunDialog)
-     * 
+     *
      * @param tree_root Initialised GMenu.TreeDirectory, or null
      */
     private void load_menus(GMenu.TreeDirectory? tree_root = null)
     {
         GMenu.TreeDirectory root;
-    
+
         // Load the tree for the first time
         if (tree == null) {
             tree = new GMenu.Tree(APPS_ID, GMenu.TreeFlags.SORT_DISPLAY_NAME);
@@ -198,17 +198,15 @@ public class BudgieMenuWindow : Budgie.Popover
                         }
                     }
 
-                    if (!menu_buttons.contains(app_id)) { // If we haven't already added this button
-                        var btn = new MenuButton(appinfo, use_root, icon_size);
+                    var btn = new MenuButton(appinfo, use_root, icon_size);
 
-                        btn.clicked.connect(()=> {
-                            hide();
-                            launch_app(btn.info);
-                        });
-                        menu_buttons.insert(app_id, btn);
-                        btn.show_all();
-                        content.add(btn);
-                    }
+                    btn.clicked.connect(()=> {
+                        hide();
+                        launch_app(btn.info);
+                    });
+                    menu_buttons.insert(app_id, btn);
+                    btn.show_all();
+                    content.add(btn);
                 }
             }
         }
@@ -411,7 +409,7 @@ public class BudgieMenuWindow : Budgie.Popover
             child = after.get_child() as MenuButton;
             next = child.parent_menu.get_name();
         }
-        
+
         // Only add one if we need one!
         if (before == null || after == null || prev != next) {
             var label = new Gtk.Label(Markup.printf_escaped("<big>%s</big>", prev));


### PR DESCRIPTION
## Description
Where a desktop entry is in more than one category that should show.  At the moment only one entry in any category is displayed which can leave empty menu categories

For example - libreoffice-math - It belongs to the Science category and the Office Category.  The current code only displays Math in the Office Category ... leaving the Science category visible in the menu but empty.

![Empty](https://user-images.githubusercontent.com/996240/54440006-ca07f700-4731-11e9-80b4-8ae961c702e4.png)


### Submitter Checklist

- [X] Squashed commits with `git rebase -i` (if needed)
- [X] Built budgie-desktop and verified that the patch worked (if needed)

Testing:

1. Checked that there were no duplicates displayed in the All category.
2. Switched on Headers - no duplicates in the All category - Math was displayed both in Office and Science.
3. Switched off Headers
4. Changed to the Compact Menu - duplicates were not displayed
5. Switched on Headers - no duplicates within categories - Math was displayed in both the Office and Science category.