### PR TITLE
Blacklist Papirus-Adapta and Papirus-Adapta-Nokto

### DIFF
--- a/src/panel/settings/themes.vala
+++ b/src/panel/settings/themes.vala
@@ -65,6 +65,8 @@ public class ThemeScanner : GLib.Object
 
     string[] icon_theme_blacklist = {
         "breeze",
+        "Papirus-Adapta",
+        "Papirus-Adapta-Nokto",
         "solus-sc"
     };
 


### PR DESCRIPTION
## Description
This commit blacklists Papirus-Adapta and Papirus-Adapta-Nokto due to not being maintained anymore along with the fact that they are there only to give old users their icons back...

### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [ ] Built budgie-desktop and verified that the patch worked (if needed)
