### PR TITLE
Add a slide animation to the IconPopover stack

### DIFF
--- a/src/applets/icon-tasklist/IconPopover.vala
+++ b/src/applets/icon-tasklist/IconPopover.vala
@@ -75,6 +75,7 @@ namespace Budgie {
              * Views
              */
             this.stack = new Gtk.Stack();
+            this.stack.transition_type = Gtk.StackTransitionType.SLIDE_LEFT_RIGHT;
             this.stack.get_style_context().add_class("icon-popover-stack");
 
             this.primary_view = new Gtk.Box(Gtk.Orientation.VERTICAL, 0);
@@ -401,7 +402,7 @@ namespace Budgie {
 
                         for (int i = 0; i < workspaces_to_remove; i++) {
                             Budgie.IconPopoverItem child = workspace_items.nth_data(i);
-    
+
                             if (child != null) {
                                 this.actions_view.remove(child);
                                 workspace_items.remove(child);


### PR DESCRIPTION
## Description

This Pull Request adds a slide animation to the IconPopover's stack. That's it.

### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
