### PR TITLE
budgie-menu: Add an option to show category icons

### DIFF
--- a/src/applets/budgie-menu/BudgieMenu.vala
+++ b/src/applets/budgie-menu/BudgieMenu.vala
@@ -1,8 +1,8 @@
 /*
  * This file is part of budgie-desktop
- * 
+ *
  * Copyright © 2015-2019 Budgie Desktop Developers
- * 
+ *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
@@ -42,6 +42,9 @@ public class BudgieMenuSettings : Gtk.Grid
     [GtkChild]
     private Gtk.Button? button_icon_pick;
 
+    [GtkChild]
+    private Gtk.Switch? switch_show_category_icons;
+
     private Settings? settings;
 
     public BudgieMenuSettings(Settings? settings)
@@ -51,6 +54,7 @@ public class BudgieMenuSettings : Gtk.Grid
         settings.bind("menu-compact", switch_menu_compact, "active", SettingsBindFlags.DEFAULT);
         settings.bind("menu-headers", switch_menu_headers, "active", SettingsBindFlags.DEFAULT);
         settings.bind("menu-categories-hover", switch_menu_categories_hover, "active", SettingsBindFlags.DEFAULT);
+        settings.bind("show-category-icons", switch_show_category_icons, "active", SettingsBindFlags.DEFAULT);
         settings.bind("menu-label", entry_label, "text", SettingsBindFlags.DEFAULT);
         settings.bind("menu-icon", entry_icon_pick, "text", SettingsBindFlags.DEFAULT);
 

--- a/src/applets/budgie-menu/BudgieMenuButtons.vala
+++ b/src/applets/budgie-menu/BudgieMenuButtons.vala
@@ -1,8 +1,8 @@
 /*
  * This file is part of budgie-desktop
- * 
+ *
  * Copyright © 2015-2019 Budgie Desktop Developers
- * 
+ *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
@@ -17,22 +17,28 @@ public class CategoryButton : Gtk.RadioButton
 
     public new GMenu.TreeDirectory? group { public get ; protected set; }
 
+    public Gtk.Image icon;
+
     public CategoryButton(GMenu.TreeDirectory? parent)
     {
         Gtk.Label lab;
 
         if (parent != null) {
             lab = new Gtk.Label(parent.get_name());
+            icon = new Gtk.Image.from_icon_name(parent.get_icon().to_string(), Gtk.IconSize.BUTTON);
         } else {
             // Special case, "All"
             lab = new Gtk.Label(_("All"));
+            icon = new Gtk.Image.from_icon_name("view-app-grid-symbolic", Gtk.IconSize.BUTTON);
         }
         lab.halign = Gtk.Align.START;
         lab.valign = Gtk.Align.CENTER;
         lab.margin_start = 10;
         lab.margin_end = 15;
+        icon.set_no_show_all(true);
 
         var layout = new Gtk.Box(Gtk.Orientation.HORIZONTAL, 0);
+        layout.pack_start(icon, false, false, 0);
         layout.pack_start(lab, true, true, 0);
         add(layout);
 

--- a/src/applets/budgie-menu/BudgieMenuWindow.vala
+++ b/src/applets/budgie-menu/BudgieMenuWindow.vala
@@ -1,8 +1,8 @@
 /*
  * This file is part of budgie-desktop
- * 
+ *
  * Copyright © 2015-2019 Budgie Desktop Developers
- * 
+ *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
@@ -39,7 +39,7 @@ public class BudgieMenuWindow : Budgie.Popover
     /* Mapped id -> button */
     protected HashTable<string,MenuButton?> menu_buttons = null;
 
-    // The current group 
+    // The current group
     protected GMenu.TreeDirectory? group = null;
     protected bool compact_mode;
     protected bool headers_visible;
@@ -77,7 +77,7 @@ public class BudgieMenuWindow : Budgie.Popover
         }
         SignalHandler.disconnect_by_func(tree, (void*)refresh_tree, this);
         this.tree = null;
-        Idle.add(()=> { 
+        Idle.add(()=> {
             load_menus(null);
             content.invalidate_headers();
             content.invalidate_filter();
@@ -111,13 +111,13 @@ public class BudgieMenuWindow : Budgie.Popover
 
     /**
      * Load "menus" (.desktop's) recursively (ripped from our RunDialog)
-     * 
+     *
      * @param tree_root Initialised GMenu.TreeDirectory, or null
      */
     private void load_menus(GMenu.TreeDirectory? tree_root = null)
     {
         GMenu.TreeDirectory root;
-    
+
         // Load the tree for the first time
         if (tree == null) {
             tree = new GMenu.Tree(APPS_ID, GMenu.TreeFlags.SORT_DISPLAY_NAME);
@@ -280,6 +280,7 @@ public class BudgieMenuWindow : Budgie.Popover
         on_settings_changed("menu-compact");
         on_settings_changed("menu-headers");
         on_settings_changed("menu-categories-hover");
+        on_settings_changed("show-category-icons");
 
         // management of our listbox
         content.set_filter_func(do_filter_list);
@@ -340,6 +341,12 @@ public class BudgieMenuWindow : Budgie.Popover
             case "menu-categories-hover":
                 /* Category hover */
                 this.rollover_menus = settings.get_boolean(key);
+                break;
+            case "show-category-icons":
+                foreach (var child in categories.get_children()) {
+                    CategoryButton category = child as CategoryButton;
+                    category.icon.set_visible(settings.get_boolean(key));
+                }
                 break;
             default:
                 // not interested
@@ -411,7 +418,7 @@ public class BudgieMenuWindow : Budgie.Popover
             child = after.get_child() as MenuButton;
             next = child.parent_menu.get_name();
         }
-        
+
         // Only add one if we need one!
         if (before == null || after == null || prev != next) {
             var label = new Gtk.Label(Markup.printf_escaped("<big>%s</big>", prev));

--- a/src/applets/budgie-menu/com.solus-project.budgie-menu.gschema.xml
+++ b/src/applets/budgie-menu/com.solus-project.budgie-menu.gschema.xml
@@ -43,6 +43,12 @@
       <summary>Activate menu categories by rolling over them</summary>
       <description>Activate menu categories by rolling over them</description>
     </key>
+
+    <key type="b" name="show-category-icons">
+      <default>false</default>
+      <summary>Whether menu categories should show an icon</summary>
+      <description>Whether menu categories should show an icon</description>
+    </key>
   </schema>
 
 </schemalist>

--- a/src/applets/budgie-menu/settings.ui
+++ b/src/applets/budgie-menu/settings.ui
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.20.0 -->
+<!-- Generated with glade 3.22.1 -->
 <interface>
   <requires lib="gtk+" version="3.12"/>
   <object class="GtkImage" id="image1">
@@ -185,6 +185,31 @@
       <packing>
         <property name="left_attach">1</property>
         <property name="top_attach">2</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkLabel" id="label7">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="halign">start</property>
+        <property name="hexpand">True</property>
+        <property name="label" translatable="yes">Show Category Icons</property>
+      </object>
+      <packing>
+        <property name="left_attach">0</property>
+        <property name="top_attach">6</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkSwitch" id="switch_show_category_icons">
+        <property name="visible">True</property>
+        <property name="can_focus">True</property>
+        <property name="halign">end</property>
+        <property name="hexpand">True</property>
+      </object>
+      <packing>
+        <property name="left_attach">1</property>
+        <property name="top_attach">6</property>
       </packing>
     </child>
   </template>


### PR DESCRIPTION
## Description

This Pull Request adds an options to show category icons on Budgie Menu, using `view-app-grid-symbolic` for the All section.

### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
