### PR TITLE
Fix several syntax issues to allow build with vala 0.42/0.44 and later

### DIFF
--- a/src/applets/icon-tasklist/Icon.vala
+++ b/src/applets/icon-tasklist/Icon.vala
@@ -31,7 +31,6 @@ public class Icon : Gtk.Image
         public get {
             return bounce_amount;
         }
-        default = 0.0;
     }
 
     public double attention {
@@ -42,7 +41,6 @@ public class Icon : Gtk.Image
         public get {
             return attention_amount;
         }
-        default = 0.0;
     }
 
     public double icon_opacity {
@@ -56,10 +54,10 @@ public class Icon : Gtk.Image
         public get {
             return opacity;
         }
-        default = 1.0;
     }
 
     public Icon() {
+        opacity = 1.0;
         size_allocate.connect(this.on_size_allocate);
     }
 

--- a/src/applets/places-indicator/ListItem.vala
+++ b/src/applets/places-indicator/ListItem.vala
@@ -20,7 +20,7 @@ public abstract class ListItem : Gtk.Box
     public signal void send_message(string message_content);
     public signal void close_popover();
 
-    public ListItem()
+    protected ListItem()
     {
         orientation = Gtk.Orientation.VERTICAL;
         spacing = 0;

--- a/src/applets/status/PowerIndicator.vala
+++ b/src/applets/status/PowerIndicator.vala
@@ -30,7 +30,6 @@ public class BatteryIcon : Gtk.Box
         public get {
             return this.percent_label.visible;
         }
-        default = false;
     }
 
     public BatteryIcon(Up.Device battery) {

--- a/src/panel/manager.vala
+++ b/src/panel/manager.vala
@@ -264,7 +264,7 @@ public class PanelManager : DesktopManager
      */
     private void window_opened(Wnck.Window window)
     {
-        unowned List<Wnck.Window>? element = window_list.find(window);
+        unowned List<unowned Wnck.Window>? element = window_list.find(window);
         if (element != null) {
             return;
         }
@@ -293,7 +293,7 @@ public class PanelManager : DesktopManager
      */
     private void window_closed(Wnck.Window window)
     {
-        unowned List<Wnck.Window>? element = window_list.find(window);
+        unowned List<unowned Wnck.Window>? element = window_list.find(window);
         if (element == null) {
             return;
         }

--- a/src/panel/panel.vala
+++ b/src/panel/panel.vala
@@ -120,7 +120,6 @@ public class Panel : Budgie.Toplevel
         public get {
             return render_scale;
         }
-        default = 0.0;
     }
 
     public bool activate_action(int remote_action)

--- a/src/raven/headerwidget.vala
+++ b/src/raven/headerwidget.vala
@@ -34,7 +34,6 @@ public class HeaderExpander : Gtk.Button
         public get {
             return this._expanded;
         }
-        default = false;
     }
 
     public HeaderExpander(HeaderWidget? owner)

--- a/src/raven/raven.vala
+++ b/src/raven/raven.vala
@@ -170,7 +170,6 @@ public class Raven : Gtk.Window
         public get {
             return this._screen_edge;
         }
-        default = Gtk.PositionType.RIGHT;
     }
 
     int our_width = 0;


### PR DESCRIPTION
## Description
Fixes syntax issues found by newer vala vesions.

```
../src/raven/headerwidget.vala:25.5-25.24: error: Property `Budgie.HeaderExpander.expanded' with custom `get' accessor and/or `set' mutator cannot have `default' value
    public bool expanded {
    ^^^^^^^^^^^^^^^^^^^^
```

```
../src/applets/places-indicator/ListItem.vala:23.5-23.19: error: Creation method of abstract class cannot be public.
    public ListItem()
    ^^^^^^^^^^^^^^^
```

### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
