### PR TITLE
Sort menu names using locale linguistic rules #1546

### DIFF
--- a/src/applets/budgie-menu/BudgieMenuWindow.vala
+++ b/src/applets/budgie-menu/BudgieMenuWindow.vala
@@ -536,12 +536,12 @@ public class BudgieMenuWindow : Budgie.Popover
         string parentA = searchable_string(child1.parent_menu.get_name());
         string parentB = searchable_string(child2.parent_menu.get_name());
         if (child1.parent_menu != child2.parent_menu && this.headers_visible) {
-            return GLib.strcmp(parentA, parentB);
+            return parentA.collate(parentB);
         }
 
         string nameA = searchable_string(child1.info.get_display_name());
         string nameB = searchable_string(child2.info.get_display_name());
-        return GLib.strcmp(nameA, nameB);
+        return nameA.collate(nameB);
     }
 
 


### PR DESCRIPTION
## Description
Resolves #1546 - vala string.collate method sorts strings using locale linguistic rules rather than as current ascii comparison.  This ensures that for languages such as french, accented characters appear together with their logical ascii equivalent.  At the moment such characters appear at the end of the All category or sub-category.

Built on Ubuntu 18.04 budgie-desktop 10.5

![image](https://user-images.githubusercontent.com/996240/59797719-50574a80-92d8-11e9-93db-e89b8877d9be.png)


### Submitter Checklist

- [X] Squashed commits with `git rebase -i` (if needed)
- [X] Built budgie-desktop and verified that the patch worked (if needed)
