### PR TITLE
Support handling of desktopicons via other methods

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -100,11 +100,6 @@ cdata.set_quoted('SYSCONFDIR', confdir)
 cdata.set_quoted('LOCALEDIR', localedir)
 cdata.set_quoted('PACKAGE_URL', 'https://budgie-desktop.org')
 
-with_desktop_icons = get_option('with-desktop-icons')
-if with_desktop_icons ==  'nautilus'
-    warning('You must have Nautilus 3.26 or older for desktop icons with Budgie')
-endif
-
 with_stateless = get_option('with-stateless')
 if with_stateless == true
     warning('Only use stateless option with a supported OS like Solus')
@@ -168,7 +163,6 @@ report = [
     '    ==============',
     '',
     '    gtk-doc:                                @0@'.format(with_gtk_doc),
-    '    desktop icons:                          @0@'.format(with_desktop_icons),
     '    stateless:                              @0@'.format(with_stateless),
 ]
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -2,4 +2,3 @@ option('with-stateless', type: 'boolean', value: false, description: 'Enable sta
 option('with-polkit', type: 'boolean', value: true, description: 'Enable PolKit support')
 option('with-bluetooth', type: 'boolean', value: true, description: 'Enable gnome-bluetooth support')
 option('with-gtk-doc', type: 'boolean', value: true, description: 'Build gtk-doc documentation')
-option('with-desktop-icons', type: 'combo', choices: ['nautilus', 'none'], value: 'nautilus', description: 'Desktop icon handling')

--- a/src/panel/com.solus-project.budgie-panel.gschema.xml
+++ b/src/panel/com.solus-project.budgie-panel.gschema.xml
@@ -33,6 +33,13 @@
       <value nick="BUDGIE_NOTIFICATION_POSITION_BOTTOM_RIGHT" value="4" />
   </enum>
 
+  <enum id="com.solus-project.budgie-panel.DesktopIconsHandler">
+      <value nick="NONE" value="1" />
+      <value nick="NAUTILUS" value="2" />
+      <value nick="NEMO" value="3" />
+      <value nick="DESKTOPFOLDER" value="4" />
+  </enum>
+
   <schema id="com.solus-project.budgie-panel.panel">
     <key enum="com.solus-project.budgie-panel.Position" name="location">
       <default>'none'</default>
@@ -157,6 +164,13 @@
       <default>'BUDGIE_NOTIFICATION_POSITION_TOP_RIGHT'</default>
       <summary>Set the location of notifications</summary>
       <description>Set the location on the screen where notification popups will appear.</description>
+    </key>
+
+    <key enum="com.solus-project.budgie-panel.DesktopIconsHandler" name="desktop-icons-handler">
+      <default>'NONE'</default>
+      <summary>Application that handles desktop-icons</summary>
+      <description>Define which application handles desktop-icons. Note.
+       NAUTILUS only applies to v3.26 and should not be used for later versions of nautilus.</description>
     </key>
 
     <key type="i" name="migration-level">

--- a/src/panel/meson.build
+++ b/src/panel/meson.build
@@ -35,13 +35,9 @@ panel_sources = [
     'settings/settings_style.vala',
     'settings/settings_wm.vala',
     'settings/themes.vala',
+    'settings/settings_desktop.vala',
     panel_resources,
 ]
-
-# Only build desktop icons pane for Nautilus right now
-if with_desktop_icons == 'nautilus'
-    panel_sources +=  'settings/settings_desktop.vala'
-endif
 
 panel_deps = [
     libplugin_vapi,
@@ -75,10 +71,6 @@ budgie_panel_vala_args = [
         '--target-glib=2.38',
         '--gresources=' + gresource,
 ]
-
-if with_desktop_icons == 'nautilus'
-    budgie_panel_vala_args += ['-D', 'HAVE_NAUTILUS']
-endif
 
 budgie_panel_c_args = [
     '-DWNCK_I_KNOW_THIS_IS_UNSTABLE'

--- a/src/panel/settings/settings_desktop.vala
+++ b/src/panel/settings/settings_desktop.vala
@@ -127,7 +127,7 @@ public class DFDesktopPage : DesktopPage {
 
         /* Hook up settings */
         var settings = new GLib.Settings("com.github.spheras.desktopfolder");
-        settings.bind("icons-on-desktop", switch_icons, "active", SettingsBindFlags.DEFAULT);
+        settings.bind("show-desktopfolder", switch_icons, "active", SettingsBindFlags.DEFAULT);
     }
 } /* End class */
 

--- a/src/panel/settings/settings_desktop.vala
+++ b/src/panel/settings/settings_desktop.vala
@@ -1,8 +1,8 @@
 /*
  * This file is part of budgie-desktop
- * 
+ *
  * Copyright © 2015-2019 Budgie Desktop Developers
- * 
+ *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
@@ -11,20 +11,9 @@
 
 namespace Budgie {
 
-/**
- * DesktopPage allows users to change aspects of the fonts used
- */
-public class DesktopPage : Budgie.SettingsPage {
-
-    private GLib.Settings bg_settings;
-    private GLib.Settings nautilus_settings;
-
-    private Gtk.Switch switch_icons;
-    private Gtk.Switch switch_home;
-    private Gtk.Switch switch_network;
-    private Gtk.Switch switch_trash;
-    private Gtk.Switch switch_mounts;
-
+public class DesktopPage: Budgie.SettingsPage {
+    protected Gtk.Switch switch_icons;
+    protected SettingsGrid grid;
 
     public DesktopPage()
     {
@@ -34,7 +23,7 @@ public class DesktopPage : Budgie.SettingsPage {
                display_weight: 1,
                icon_name: "preferences-desktop-wallpaper");
 
-        var grid = new SettingsGrid();
+        grid = new SettingsGrid();
         this.add(grid);
 
         /* Allow icons */
@@ -42,9 +31,34 @@ public class DesktopPage : Budgie.SettingsPage {
         grid.add_row(new SettingsRow(switch_icons,
             _("Desktop Icons"),
             _("Control whether to allow launchers and icons on the desktop.")));
+    }
+}
 
-        /* Hook up settings */
+/**
+ * NautilusDesktopPage allows users to change aspects of the fonts used
+ * for the nautilus desktop
+ */
+public class NautilusDesktopPage : DesktopPage {
+
+    protected GLib.Settings bg_settings;
+    protected GLib.Settings desktop_settings;
+
+    private Gtk.Switch switch_home;
+    private Gtk.Switch switch_network;
+    private Gtk.Switch switch_trash;
+    private Gtk.Switch switch_mounts;
+
+    protected virtual void bind_settings() {
         bg_settings = new GLib.Settings("org.gnome.desktop.background");
+        desktop_settings = new GLib.Settings("org.gnome.nautilus.desktop");
+    }
+
+    public NautilusDesktopPage()
+    {
+        base();
+
+        bind_settings();
+        /* Hook up settings */
         bg_settings.bind("show-desktop-icons", switch_icons, "active", SettingsBindFlags.DEFAULT);
         bg_settings.changed["show-desktop-icons"].connect(this.update_switches);
 
@@ -72,27 +86,49 @@ public class DesktopPage : Budgie.SettingsPage {
             _("Mounted volumes"),
             _("Mounted volumes & drives will appear on the desktop.")));
 
-
-        nautilus_settings = new GLib.Settings("org.gnome.nautilus.desktop");
-        nautilus_settings.bind("home-icon-visible", switch_home, "active", SettingsBindFlags.DEFAULT);
-        nautilus_settings.bind("network-icon-visible", switch_network, "active", SettingsBindFlags.DEFAULT);
-        nautilus_settings.bind("trash-icon-visible", switch_trash, "active", SettingsBindFlags.DEFAULT);
-        nautilus_settings.bind("volumes-visible", switch_mounts, "active", SettingsBindFlags.DEFAULT);
+        desktop_settings.bind("home-icon-visible", switch_home, "active", SettingsBindFlags.DEFAULT);
+        desktop_settings.bind("network-icon-visible", switch_network, "active", SettingsBindFlags.DEFAULT);
+        desktop_settings.bind("trash-icon-visible", switch_trash, "active", SettingsBindFlags.DEFAULT);
+        desktop_settings.bind("volumes-visible", switch_mounts, "active", SettingsBindFlags.DEFAULT);
 
         update_switches();
     }
 
     void update_switches()
     {
-#if 0
         bool b = bg_settings.get_boolean("show-desktop-icons");
         switch_home.sensitive = b;
         switch_network.sensitive = b;
         switch_trash.sensitive = b;
         switch_mounts.sensitive = b;
-#endif
     }
-    
+
+} /* End class */
+
+/**
+ * NemoDesktopPage allows users to change aspects of the fonts used
+ * for the nemo desktop
+ */
+public class NemoDesktopPage : NautilusDesktopPage {
+    protected override void bind_settings() {
+        bg_settings = new GLib.Settings("org.nemo.desktop");
+        desktop_settings = new GLib.Settings("org.nemo.desktop");
+    }
+} /* End class */
+
+/**
+ * DFDesktopPage allows users to change to switch desktop-icons
+ * on/off for DesktopFolder
+ */
+public class DFDesktopPage : DesktopPage {
+    public DFDesktopPage()
+    {
+        base();
+
+        /* Hook up settings */
+        var settings = new GLib.Settings("com.github.spheras.desktopfolder");
+        settings.bind("icons-on-desktop", switch_icons, "active", SettingsBindFlags.DEFAULT);
+    }
 } /* End class */
 
 } /* End namespace */

--- a/src/panel/settings/settings_main.vala
+++ b/src/panel/settings/settings_main.vala
@@ -1,8 +1,8 @@
 /*
  * This file is part of budgie-desktop
- * 
+ *
  * Copyright © 2015-2019 Budgie Desktop Developers
- * 
+ *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
@@ -101,11 +101,26 @@ public class SettingsWindow : Gtk.Window {
     {
         this.add_page(new Budgie.StylePage());
 
-#if HAVE_NAUTILUS
-        if (Environment.find_program_in_path("nautilus") != null) {
-            this.add_page(new Budgie.DesktopPage());
+        var panel_settings = new GLib.Settings("com.solus-project.budgie-panel");
+        var desktop_icons_source = panel_settings.get_string("desktop-icons-handler");
+
+        switch (desktop_icons_source) {
+            case "NAUTILUS":
+                if (Environment.find_program_in_path("nautilus") != null) {
+                    this.add_page(new Budgie.NautilusDesktopPage());
+                }
+                break;
+            case "NEMO":
+                if (Environment.find_program_in_path("nemo-desktop") != null) {
+                    this.add_page(new Budgie.NemoDesktopPage());
+                }
+                break;
+            case "DESKTOPFOLDER":
+                if (Environment.find_program_in_path("desktopfolder") != null) {
+                    this.add_page(new Budgie.DFDesktopPage());
+                }
+                break;
         }
-#endif
 
         this.add_page(new Budgie.FontPage());
         this.add_page(new Budgie.WindowsPage());


### PR DESCRIPTION
## Description
Currently desktop icons handling via budgie-desktop is an either/or i.e. nautilus 3.26 or nothing.  This is inflexible for both distros and "tinkerers". 

This PR replaces the compile-time option "with-desktop-icons" with a gsettings key allowing desktop icons to be handled by nautilus, nemo, desktopfolder or just no desktop icons (by default).

Thus distros will replace the compile time option with an override.  This does not introduce any new translations.

### Submitter Checklist

- [ ] Squashed commits with `git rebase -i` (if needed)
- [X] Built budgie-desktop and verified that the patch worked (if needed)

Ubuntu Budgie 18.04 with budgie-desktop 10.5.  Tested with nautilus 3.26, nemo, desktopfolder and no desktopicons.
