### PR TITLE
Add slight delay before integrating tray #1249

### DIFF
--- a/src/applets/tray/TrayApplet.vala
+++ b/src/applets/tray/TrayApplet.vala
@@ -40,7 +40,11 @@ public class TrayApplet : Budgie.Applet
         vexpand = false;
 
         show_all();
-        maybe_integrate_tray();
+        Timeout.add_seconds(1,()=> {
+            maybe_integrate_tray();
+            return false;
+        });
+
         panel_size_changed.connect((p,i,s)=> {
             this.icon_size = s;
             if (tray != null) {


### PR DESCRIPTION
## Description
Race condition between the Na.Tray initialisation
and the panel initialisation can cause redrawing
issues. Adding a delay ensures that the Na.Tray is
drawn on a fully initialised panel.

Tested on three different laptops - 'craptop', mid range and high end 4k over the weekend. Cannot reproduce the issue that was previously easily reproducible on a GNOME 3.34 stack

... and yes does feel like another sticking plaster - but I think is worthy of wider testing.

### Submitter Checklist

- [X] Squashed commits with `git rebase -i` (if needed)
- [X] Built budgie-desktop and verified that the patch worked (if needed)
