### PR TITLE
Add missing LEFT/RIGHT panel layouts

### DIFF
--- a/src/panel/manager.vala
+++ b/src/panel/manager.vala
@@ -1281,6 +1281,12 @@ public class PanelManager : DesktopManager
                         case "top":
                             position = PanelPosition.TOP;
                             break;
+                        case "left":
+                            position = PanelPosition.LEFT;
+                            break;
+                        case "right":
+                            position = PanelPosition.RIGHT;
+                            break;
                         default:
                             position = PanelPosition.BOTTOM;
                             break;


### PR DESCRIPTION
## Description
Anyone who tries to customise their panel layout via panel.ini cannot currently do so for panels in a left or right position.

Patch allows this - tested this with a panel.ini in top/left/bottom/right position including panel.ini with two panel positions (top and left)


### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
