### PR TITLE
Disable the ability to select notifications in Raven

### DIFF
--- a/src/raven/notifications_group.vala
+++ b/src/raven/notifications_group.vala
@@ -1,8 +1,8 @@
 /*
  * This file is part of budgie-desktop
- * 
+ *
  * Copyright © 2015-2019 Budgie Desktop Developers
- * 
+ *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
@@ -52,6 +52,7 @@ namespace Budgie {
             list = new Gtk.ListBox();
             list.can_focus = false; // Disable focus to prevent scroll on click
             list.focus_on_click = false;
+            list.set_selection_mode(Gtk.SelectionMode.NONE);
 
             /**
              * Header creation

--- a/src/raven/notifications_view.vala
+++ b/src/raven/notifications_view.vala
@@ -932,6 +932,7 @@ public class NotificationsView : Gtk.Box
         pack_start(scrolledwindow, true, true, 0);
 
         listbox = new Gtk.ListBox();
+        listbox.set_selection_mode(Gtk.SelectionMode.NONE);
         var placeholder = new NotificationPlaceholder();
         listbox.set_placeholder(placeholder);
         scrolledwindow.add(listbox);


### PR DESCRIPTION
## Description
This prevents clicks on notifications or notification groups in Raven from selecting them. Currently, when clicking a notification, it will be changed visually, and there is no way to easily unselect it. There are no actions that make use of selections, so this doesn't break anything. With this change, a click won't do any unexpected things.

Possibly related to #1765 along with commit 99f952d.

### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
