### PR TITLE
Release TabSwitcher on any modifier, locked modifiers ignored. Closes #1971

### DIFF
--- a/src/daemon/tabswitcher.vala
+++ b/src/daemon/tabswitcher.vala
@@ -327,7 +327,7 @@ public class TabSwitcher : Object
         mod_timeout = 0;
         Gdk.ModifierType modifier;
         Gdk.Display.get_default().get_default_seat().get_pointer().get_state(Gdk.get_default_root_window(), null, out modifier);
-        if ((modifier & Gdk.ModifierType.MOD1_MASK) == 0 && (modifier & Gdk.ModifierType.MOD4_MASK) == 0) {
+        if ((modifier & Gdk.ModifierType.MODIFIER_MASK ) == 0 || (modifier & Gdk.ModifierType.MODIFIER_MASK ) == 2 ) {
             switcher_window.hide();
             return false;
         }


### PR DESCRIPTION
## Description
TabSwitcher will now release once the modifier mask reaches 0 or 2 (2 being a locked modifier such as capslock).

Continuation of earlier ticket #1668 #1705 and resolution my opened ticket #1971.

### Submitter Checklist

- [ x ] Squashed commits with `git rebase -i` (if needed)
- [ x ] Built budgie-desktop and verified that the patch worked (if needed)
