### PR TITLE
Make it so middle click on icon-tasklist icon create a new instance of window

### DIFF
--- a/src/applets/icon-tasklist/IconButton.vala
+++ b/src/applets/icon-tasklist/IconButton.vala
@@ -966,6 +966,35 @@ public class IconButton : Gtk.ToggleButton
             } else {
                 launch_app(event.time);
             }
+        } else if (event.button == 2) { // Middle click
+            GLib.List<unowned Wnck.Window> windows;
+            bool middle_click_create_new_instance = false;
+
+            if (this.settings != null) { // Settings defined
+                middle_click_create_new_instance = this.settings.get_boolean("middle-click-launch-new-instance");
+            }
+
+            if (middle_click_create_new_instance) {
+                if (class_group != null) {
+                    windows = class_group.get_windows().copy();
+                } else {
+                    windows = new GLib.List<unowned Wnck.Window>();
+                }
+    
+                if (windows.length() == 0) {
+                    launch_app(Gtk.get_current_event_time());
+                } else if (this.app_info != null) {
+                    string[] actions = app_info.list_actions();
+    
+                    if ("new-window" in actions) { // If we have a preferred action set
+                        launch_context.set_screen(get_screen());
+                        launch_context.set_timestamp(Gdk.CURRENT_TIME);
+                        this.app_info.launch_action("new-window", launch_context);
+                    } else {
+                        launch_app(Gtk.get_current_event_time());
+                    }
+                }
+            }
         }
 
         return base.button_release_event(event);

--- a/src/applets/icon-tasklist/IconTasklistApplet.vala
+++ b/src/applets/icon-tasklist/IconTasklistApplet.vala
@@ -34,6 +34,9 @@ public class IconTasklistSettings : Gtk.Grid
     [GtkChild]
     private Gtk.Switch? show_all_on_click;
 
+    [GtkChild]
+    private Gtk.Switch? switch_middle_click_create_new_instance;
+
     private GLib.Settings? settings;
 
     public IconTasklistSettings(GLib.Settings? settings)
@@ -44,6 +47,7 @@ public class IconTasklistSettings : Gtk.Grid
         settings.bind("lock-icons", switch_lock_icons, "active", SettingsBindFlags.DEFAULT);
         settings.bind("only-pinned", switch_only_pinned, "active", SettingsBindFlags.DEFAULT);
         settings.bind("show-all-windows-on-click", show_all_on_click, "active", SettingsBindFlags.DEFAULT);
+        settings.bind("middle-click-launch-new-instance", switch_middle_click_create_new_instance, "active", SettingsBindFlags.DEFAULT);
     }
 
 }

--- a/src/applets/icon-tasklist/com.solus-project.icon-tasklist.gschema.xml
+++ b/src/applets/icon-tasklist/com.solus-project.icon-tasklist.gschema.xml
@@ -36,5 +36,11 @@
       <summary>Show All Windows On Click</summary>
       <description>Show all windows when clicking their respective IconButton in the IconTasklist.</description>
     </key>
+
+    <key type="b" name="middle-click-launch-new-instance">
+      <default>false</default>
+      <summary>Middle Click To Launch New Window</summary>
+      <description>Launch a new window when middle clicking an IconButton in the IconTasklist.</description>
+    </key>
   </schema>
 </schemalist>

--- a/src/applets/icon-tasklist/settings.ui
+++ b/src/applets/icon-tasklist/settings.ui
@@ -129,5 +129,29 @@
         <property name="top_attach">0</property>
       </packing>
     </child>
+    <child>
+      <object class="GtkLabel" id="label6">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="halign">start</property>
+        <property name="label" translatable="yes">Middle click to launch new window</property>
+      </object>
+      <packing>
+        <property name="left_attach">0</property>
+        <property name="top_attach">5</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkSwitch" id="switch_middle_click_create_new_instance">
+        <property name="visible">True</property>
+        <property name="can_focus">True</property>
+        <property name="halign">end</property>
+        <property name="hexpand">True</property>
+      </object>
+      <packing>
+        <property name="left_attach">1</property>
+        <property name="top_attach">5</property>
+      </packing>
+    </child>
   </template>
 </interface>


### PR DESCRIPTION
## Description

This PR implements the ability to use middle click in order to open a new instance of an application. 
In order to avoid breaking existing code, I reused the code of the popover and adapted where it was needed :smile: 

### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
