### PR TITLE
Show windows from all workspaces in TabSwitcher

### DIFF
--- a/src/panel/settings/settings_wm.vala
+++ b/src/panel/settings/settings_wm.vala
@@ -24,6 +24,7 @@ public class WindowsPage : Budgie.SettingsPage {
     private Gtk.Switch switch_focus;
     private Gtk.Switch switch_tiling;
     private Gtk.Switch switch_unredirect;
+    private Gtk.Switch switch_all_windows_tabswitcher;
 
     public WindowsPage()
     {
@@ -79,6 +80,12 @@ public class WindowsPage : Budgie.SettingsPage {
             _("This option is for advanced users. Use this if you are having graphical or performance issues with dedicated GPUs.")
         ));
 
+        switch_all_windows_tabswitcher = new Gtk.Switch();
+        grid.add_row(new SettingsRow(switch_all_windows_tabswitcher,
+            _("Show all windows in tab switcher"),
+            _("All tabs will be displayed in tab switcher regardless of the workspace in use.")
+        ));
+
         /* Button layout  */
         var model = new Gtk.ListStore(2, typeof(string), typeof(string));
         Gtk.TreeIter iter;
@@ -103,6 +110,7 @@ public class WindowsPage : Budgie.SettingsPage {
         budgie_wm_settings.bind("edge-tiling", switch_tiling,  "active", SettingsBindFlags.DEFAULT);
         budgie_wm_settings.bind("focus-mode", switch_focus, "active", SettingsBindFlags.DEFAULT);
         budgie_wm_settings.bind("force-unredirect", switch_unredirect, "active", SettingsBindFlags.DEFAULT);
+        budgie_wm_settings.bind("show-all-windows-tabswitcher", switch_all_windows_tabswitcher, "active", SettingsBindFlags.DEFAULT);
     }
 
 } /* End class */

--- a/src/wm/com.solus-project.budgie.wm.gschema.xml
+++ b/src/wm/com.solus-project.budgie.wm.gschema.xml
@@ -79,6 +79,12 @@
       <description>Disables the screen unredirection which may improve performance with certain drivers.</description>
     </key>
 
+    <key type="b" name="show-all-windows-tabswitcher">
+      <default>false</default>
+      <summary>Enable display of every open windows in the tab switcher</summary>
+      <description>Control whether every open windows or only the current workspace ones are displayed in the tab switcher.</description>
+    </key>
+
     <key type="as" name="toggle-raven">
       <default><![CDATA[['<Super>A']]]></default>
       <summary>The binding to use to toggle Raven applets view</summary>

--- a/src/wm/wm.vala
+++ b/src/wm/wm.vala
@@ -1126,13 +1126,13 @@ public class BudgieWM : Meta.Plugin
         last_time = cur_time;
 
         if (cur_tabs == null) {
-            cur_tabs = display.get_tab_list(Meta.TabList.NORMAL, workspace);
-            CompareFunc<weak Meta.Window> cm = Budgie.BudgieWM.tab_sort_reverse;
-            cur_tabs.sort(cm);
+            cur_tabs = this.get_current_tabs(display, workspace, this.settings.get_boolean("show-all-windows-tabswitcher"));
         }
+
         if (cur_tabs == null) {
             return;
         }
+
         switch_switcher(true); /* true as in "yes, backward" */
     }
 
@@ -1162,13 +1162,13 @@ public class BudgieWM : Meta.Plugin
         last_time = cur_time;
 
         if (cur_tabs == null) {
-            cur_tabs = display.get_tab_list(Meta.TabList.NORMAL, workspace);
-            CompareFunc<weak Meta.Window> cm = Budgie.BudgieWM.tab_sort;
-            cur_tabs.sort(cm);
+            cur_tabs = this.get_current_tabs(display, workspace, this.settings.get_boolean("show-all-windows-tabswitcher"));
         }
+
         if (cur_tabs == null) {
             return;
         }
+
         switch_switcher();
     }
 
@@ -1198,6 +1198,26 @@ public class BudgieWM : Meta.Plugin
         }
         uint32 curr_xid = (uint32)win.get_xwindow();
         switcher_proxy.ShowSwitcher.begin(curr_xid);
+    }
+
+    /* Return sorted list of user open tabs */
+    private List<weak Meta.Window> get_current_tabs(Meta.Display display, 
+                     Meta.Workspace workspace, 
+                     bool getTabsForAllWindows)
+    {
+        List<weak Meta.Window> tabs;
+        CompareFunc<weak Meta.Window> cm = Budgie.BudgieWM.tab_sort_reverse;
+
+        if (getTabsForAllWindows) {
+            tabs = display.get_tab_list(Meta.TabList.NORMAL, null);
+        } else {
+            //  Return only tabs for the current workspace
+            tabs = display.get_tab_list(Meta.TabList.NORMAL, workspace);
+        }
+
+        tabs.sort(cm);
+
+        return tabs;
     }
 
     public void stop_switch_windows() {


### PR DESCRIPTION
## Description

This PR provide an option in order to display every open windows in the tab switcher no matter the workspace.

This should close #1891 and #943.

Thanks for the review!

### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
