### PR TITLE
Cleanup wnck usage on shutdown to prevent crashes - Closes #1201

### DIFF
--- a/src/daemon/main.vala
+++ b/src/daemon/main.vala
@@ -91,8 +91,7 @@ public static int main(string[] args) {
     manager = null;
     end_dialog = null;
     settings = null;
-
-    Wnck.shutdown();
+    screen = null;
 
     return 0;
 }


### PR DESCRIPTION
## Description
resolves #1201 - crashes observed when logging out/reboot and logging in.

In Ubuntu we have automatic error reporting (apport) that sends /var/crash reports to errors.ubuntu.com - hundreds of error reports every week have been reported for budgie-desktop for the last 4 years.

I've tracked this down to how budgie-desktop is handling wnck cleanup - in essence forcing a wnck shutdown is invalid because all corresponding wnck references must be first tidied up before forcing a shutdown.  Wnck is used all over the shop in the code-base and shutdown and reference cleanup is not accounted for.  Being pragmatic - its easier to cleanup with another form of the API that doesn't invoke the crash reports. 

This patch has been tested over the last four months on 20.04 & 18.04 (v10.5.1 and v10.5) and the crash reports in this area are no longer observed.

As an aside - i've tidied up a couple of compilation warning issues outstanding for the polkitdialog module (line 73 and 218)

### Submitter Checklist

- [X] Squashed commits with `git rebase -i` (if needed)
- [X] Built budgie-desktop and verified that the patch worked (if needed)
