### PR TITLE
Make screenshot commands configurable

### DIFF
--- a/src/wm/com.solus-project.budgie.wm.gschema.xml
+++ b/src/wm/com.solus-project.budgie.wm.gschema.xml
@@ -97,16 +97,34 @@
       <description>Take screenshot of all displays</description>
     </key>
 
+    <key type="s" name="full-screenshot-cmd">
+      <default>'gnome-screenshot'</default>
+      <summary>Take screenshot of all displays application</summary>
+      <description>Application that is run when taking a screenshot of all displays</description>
+    </key>
+
     <key type="as" name="take-region-screenshot">
       <default><![CDATA[['<Ctrl>Print']]]></default>
       <summary>Take screenshot of selectable region</summary>
       <description>Take screenshot of selectable region</description>
     </key>
 
+    <key type="s" name="take-region-screenshot-cmd">
+      <default>'gnome-screenshot -a'</default>
+      <summary>Take screenshot of selectable region application</summary>
+      <description>Application that is run when taking a screenshot of a selectable region</description>
+    </key>
+
     <key type="as" name="take-window-screenshot">
       <default><![CDATA[['<Alt>Print']]]></default>
       <summary>Take screenshot of current window</summary>
       <description>Take screenshot of current window</description>
+    </key>
+
+    <key type="s" name="take-window-screenshot-cmd">
+      <default>'gnome-screenshot -w -b'</default>
+      <summary>Take screenshot of current window application</summary>
+      <description>Application that is run when taking a screenshot of the current window</description>
     </key>
 
     <key type="as" name="toggle-notifications">

--- a/src/wm/wm.vala
+++ b/src/wm/wm.vala
@@ -304,7 +304,9 @@ public class BudgieWM : Meta.Plugin
     /* Binding for take-full-screenshot */
     void on_take_full_screenshot(Meta.Display display, Meta.Window? window, Clutter.KeyEvent? event, Meta.KeyBinding binding) {
         try {
-            Process.spawn_command_line_async ("gnome-screenshot");
+            string cmd=this.settings.get_string("full-screenshot-cmd");
+            if (cmd != "")
+                Process.spawn_command_line_async (cmd);
         } catch (SpawnError e) {
             print ("Error: %s\n", e.message);
         }
@@ -313,7 +315,9 @@ public class BudgieWM : Meta.Plugin
     /* Binding for take-region-screenshot */
     void on_take_region_screenshot(Meta.Display display, Meta.Window? window, Clutter.KeyEvent? event, Meta.KeyBinding binding) {
         try {
-            Process.spawn_command_line_async ("gnome-screenshot -a");
+            string cmd=this.settings.get_string("take-region-screenshot-cmd");
+            if (cmd != "")
+                Process.spawn_command_line_async (cmd);
         } catch (SpawnError e) {
             print ("Error: %s\n", e.message);
         }
@@ -322,7 +326,9 @@ public class BudgieWM : Meta.Plugin
     /* Binding for take-window-screenshot */
     void on_take_window_screenshot(Meta.Display display, Meta.Window? window, Clutter.KeyEvent? event, Meta.KeyBinding binding) {
         try {
-            Process.spawn_command_line_async ("gnome-screenshot -w -b");
+            string cmd=this.settings.get_string("take-window-screenshot-cmd");
+            if (cmd != "")
+                Process.spawn_command_line_async (cmd);
         } catch (SpawnError e) {
             print ("Error: %s\n", e.message);
         }


### PR DESCRIPTION
## Description
Several requests have been made by various Ubuntu Budgie community members to use alternative screenshot apps for print, alt print, ctrl print rather than having to fiddle with unsetting/manual keyboard shortcuts

This PR allows tinkerers to use dconf user session/overrides to replace gnome-screenshot with another app i.e. don't hard code the usage of the gnome-screenshot app into budgie-desktop.

### Submitter Checklist

- [X] Squashed commits with `git rebase -i` (if needed)
- [X] Built budgie-desktop and verified that the patch worked (if needed)
