### PR TITLE
Show non-xkb layouts Closes #1785

### DIFF
--- a/src/applets/keyboard-layout/KeyboardLayoutApplet.vala
+++ b/src/applets/keyboard-layout/KeyboardLayoutApplet.vala
@@ -1,8 +1,8 @@
 /*
  * This file is part of budgie-desktop
- * 
+ *
  * Copyright © 2015-2019 Budgie Desktop Developers
- * 
+ *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
@@ -32,7 +32,7 @@ errordomain InputMethodError {
 class AppletIBusManager : GLib.Object
 {
     private HashTable<string,weak IBus.EngineDesc> engines = null;
-
+    private List<IBus.EngineDesc>? enginelist = null;
     private bool did_ibus_init = false;
     private bool ibus_available = true;
     private IBus.Bus? bus = null;
@@ -83,10 +83,10 @@ class AppletIBusManager : GLib.Object
     private void on_engines_get(GLib.Object? o, GLib.AsyncResult? res)
     {
         try {
-            var engines = this.bus.list_engines_async_finish(res);
+            this.enginelist = this.bus.list_engines_async_finish(res);
             this.reset_ibus();
             /* Store reference to the engines */
-            foreach (var engine in engines) {
+            foreach (var engine in this.enginelist) {
                 this.engines[engine.get_name()] = engine;
             }
         } catch (Error e) {
@@ -125,8 +125,11 @@ class AppletIBusManager : GLib.Object
      * Attempt to grab the ibus engine for the given name if it
      * exists, or returns null
      */
-    public weak IBus.EngineDesc? get_engine(string name)
+    public unowned IBus.EngineDesc? get_engine(string name)
     {
+        if (this.engines == null) {
+            return null;
+        }
         return this.engines.lookup(name);
     }
 }

--- a/src/wm/ibus.vala
+++ b/src/wm/ibus.vala
@@ -23,7 +23,8 @@ public class IBusManager : GLib.Object
     private IBus.Bus? bus = null;
     private bool ibus_available = true;
 
-    private HashTable<string,unowned IBus.EngineDesc> engines = null;
+    private HashTable<string,weak IBus.EngineDesc> engines = null;
+    private List<IBus.EngineDesc>? enginelist = null;
 
     public unowned Budgie.KeyboardManager? kbm { construct set ; public get; }
 
@@ -54,7 +55,7 @@ public class IBusManager : GLib.Object
             return;
         }
 
-        this.engines = new HashTable<string,unowned IBus.EngineDesc>(str_hash, str_equal);
+        this.engines = new HashTable<string,weak IBus.EngineDesc>(str_hash, str_equal);
 
         /* Get the bus */
         bus = new IBus.Bus();
@@ -92,16 +93,16 @@ public class IBusManager : GLib.Object
      */
     private void reset_ibus()
     {
-        this.engines = new HashTable<string,unowned IBus.EngineDesc>(str_hash, str_equal);
+        this.engines = new HashTable<string,weak IBus.EngineDesc>(str_hash, str_equal);
     }
 
     private void on_engines_get(GLib.Object? o, GLib.AsyncResult? res)
     {
         try {
-            var engines = this.bus.list_engines_async_finish(res);
+            this.enginelist = this.bus.list_engines_async_finish(res);
             this.reset_ibus();
             /* Store reference to the engines */
-            foreach (var engine in engines) {
+            foreach (var engine in this.enginelist) {
                 this.engines[engine.get_name()] = engine;
             }
         } catch (Error e) {


### PR DESCRIPTION
## Description
Enables non-xkb layouts to be displayed and used from the keyboard indicator applet

Tested with en_gb, en_US and Japanese Kana keyboard layouts on UB 20.04 - switch between the three - logging and logging in each one and checking that the last layout used remains as the default on logon.

Now - I'm not a multiple keyboard layout user - but I think this is ready at least for wider testing.

### Submitter Checklist

- [X] Squashed commits with `git rebase -i` (if needed)
- [X] Built budgie-desktop and verified that the patch worked (if needed)
