### PR TITLE
Remove reentrant panel removal crash

### DIFF
--- a/src/panel/panel.vala
+++ b/src/panel/panel.vala
@@ -701,6 +701,10 @@ public class Panel : Budgie.Toplevel
 
     public override void remove_applet(Budgie.AppletInfo? info)
     {
+        if (info == null) {
+            return;
+        }
+
         int position = info.position;
         string alignment = info.alignment;
         string uuid = info.uuid;


### PR DESCRIPTION
## Description
Removes a potential panel crash when removing applet(s) from a panel.

I've seen quite a few automatic error reports on launchpad over the years that looked like this

![image](https://user-images.githubusercontent.com/996240/85182871-e1615880-b281-11ea-9727-7c2675a1f72a.png)

Unlike the above though - the error reports were of crash reports without the debug info needed to identify where the issue actually occurred in the code.

Fortunately I managed to reproduce this when debugging other budgie-desktop issues and the issue was identified to be trying to use a variable when that variable is null i.e. the parameter to the identified function can be null - but no checks was made before immediately using that variable in the very first line of the function.

I think that this occurs because the function in question can be triggered twice (or more) and in this case, the info variable is null.

This PR just adds a null guard check.

### Submitter Checklist

- [X] Squashed commits with `git rebase -i` (if needed)
- [X] Built budgie-desktop and verified that the patch worked (if needed)
