### PR TITLE
Tooltip fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 /build/
 node_modules/
 
+# for debugging purposes
+justfile
+nohup.out

--- a/src/applets/notifications/NotificationsApplet.vala
+++ b/src/applets/notifications/NotificationsApplet.vala
@@ -48,7 +48,7 @@ public class NotificationsApplet : Budgie.Applet {
         widget.add(icon);
 
         icon.halign = Gtk.Align.CENTER;
-        icon.valign = Gtk.Align.CENTER;
+        icon.valign = Gtk.Align.FILL;
 
         Bus.get_proxy.begin<RavenRemote>(BusType.SESSION, RAVEN_DBUS_NAME, RAVEN_DBUS_OBJECT_PATH, 0, null, on_raven_get);
 

--- a/src/applets/workspaces/WorkspaceItem.vala
+++ b/src/applets/workspaces/WorkspaceItem.vala
@@ -235,7 +235,7 @@ public class WorkspaceItem : Gtk.EventBox
             if (window_counter < max_items || num_windows == max_items) {
                 icon_grid.attach(icon, column_counter, row_counter);
                 icon.halign = Gtk.Align.CENTER;
-                icon.valign = Gtk.Align.CENTER;
+                icon.valign = Gtk.Align.FILL;
             } else if (window_counter == max_items) {
                 Gtk.EventBox ebox = new Gtk.EventBox();
                 ebox.add(more_label);


### PR DESCRIPTION
## Description
Fixes #1954 for applets other than system tray (which requires a full rewrite to fix this issue). This namely fixes both the workspace applet and notification applet placing their tooltips offscreen at reasonable panel sizes.

### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
