### PR TITLE
Fix numerous issues with carbontray integration

### DIFF
--- a/src/applets/tray/carbontray/child.c
+++ b/src/applets/tray/carbontray/child.c
@@ -150,18 +150,14 @@ static void carbon_child_realize(GtkWidget *widget) {
 
 static void carbon_child_get_preferred_width(GtkWidget *base, int *minimum_width, int *natural_width) {
 	CarbonChild *self = CARBON_CHILD(base);
-    int scale = gtk_widget_get_scale_factor(base);
-
-    *minimum_width = self->preferredWidth / scale;
-    *natural_width = self->preferredWidth / scale;
+    *minimum_width = self->preferredWidth;
+    *natural_width = self->preferredWidth;
 }
 
 static void carbon_child_get_preferred_height(GtkWidget *base, int *minimum_height, int *natural_height) {
 	CarbonChild *self = CARBON_CHILD(base);
-    int scale = gtk_widget_get_scale_factor(base);
-
-    *minimum_height = self->preferredHeight / scale;
-    *natural_height = self->preferredHeight / scale;
+    *minimum_height = self->preferredHeight;
+    *natural_height = self->preferredHeight;
 }
 
 static void carbon_child_class_init(CarbonChildClass *klass) {


### PR DESCRIPTION
## Description

The changes within this PR can be summarized in three sections.

### Reintegration
The tray applet will now unregister its carbontray instance when the applet itself is destroyed. In addition, the tray applet will now reintegrate an instance of carbontray within the applet if the parent widget of the applet is changed, or if the monitors connected to the system change their status.

This fixes the following issues:
- Deleting and re-adding the system tray applet causes the applet to become invisible
- Changing the DPI of the connected displays causes glitchy icons
- Turning a screen off and back on causes glitchy and unresponsive icons in HiDPI mode
- Changing the position of the system tray applet causes additional (and unresponsive) nm-applet icons to spawn

### One at a Time
Previously, multiple tray applets could be created across any number of panels, which leads to strange behavior as multiple carbontray instances are fighting for registration. Now, if any additional tray applets are added, they spawn a label instead that says "Only one tray can be active at a time."

### Reasonable DPI
Previously, carbontray's icons would attempt to counteract the GTK scale factor when sizing themselves. This was a behavior taken from na-tray, and I have removed it so as to make icon sizes more consistent and give more control of DPI sizing to GTK.

### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
