### PR TITLE
Fix integration issues with carbontray

### DIFF
--- a/src/applets/tray/TrayApplet.vala
+++ b/src/applets/tray/TrayApplet.vala
@@ -39,7 +39,7 @@ private class TrayErrorIcon {
         parent.add(new Gtk.Image.from_icon_name("gtk-dialog-error", Gtk.IconSize.LARGE_TOOLBAR));
 
         popover = new Budgie.Popover(parent);
-        popover.border_width = 8;
+        popover.get_style_context().add_class("system-tray-popover");
 
         Gtk.Label label = new Gtk.Label(text);
         label.show();
@@ -86,6 +86,8 @@ public class TrayApplet : Budgie.Applet {
     public TrayApplet(string uuid) {
         Object(uuid: uuid);
 
+        get_style_context().add_class("system-tray-applet");
+
         box = new Gtk.EventBox();
         add(box);
 
@@ -93,10 +95,8 @@ public class TrayApplet : Budgie.Applet {
         settings_prefix = "/com/solus-project/budgie-panel/instance/tray";
 
         settings = get_applet_settings(uuid);
-        settings.changed.connect((key) => {
-            if (key == "spacing" && tray != null) {
-                tray.set_spacing(settings.get_int(key));
-            }
+        settings.changed["spacing"].connect((key) => {
+            if (tray != null) tray.set_spacing(settings.get_int("spacing"));
         });
 
         if (activeUuid == null) {

--- a/src/applets/tray/TrayApplet.vala
+++ b/src/applets/tray/TrayApplet.vala
@@ -28,12 +28,60 @@ public class TraySettings : Gtk.Grid {
     }
 }
 
+private class TrayErrorIcon {
+    public Budgie.PopoverManager manager;
+    public Budgie.Popover popover;
+    private Gtk.EventBox parent;
+
+    public TrayErrorIcon(Gtk.EventBox parent, string text) {
+        this.parent = parent;
+
+        parent.add(new Gtk.Image.from_icon_name("gtk-dialog-error", Gtk.IconSize.LARGE_TOOLBAR));
+
+        popover = new Budgie.Popover(parent);
+        popover.border_width = 8;
+
+        Gtk.Label label = new Gtk.Label(text);
+        label.show();
+        popover.add(label);
+        popover.hide();
+
+        parent.button_press_event.connect(on_button_press);
+    }
+
+    ~TrayErrorIcon() {
+        parent.button_press_event.disconnect(on_button_press);
+    }
+
+    public void register(Budgie.PopoverManager newManager) {
+        manager = newManager;
+        manager.register_popover(parent, popover);
+    }
+
+    private bool on_button_press(Gdk.EventButton event) {
+        if (event.button != 1) {
+            return Gdk.EVENT_PROPAGATE;
+        }
+        if (popover.get_visible()) {
+            popover.hide();
+        } else {
+            manager.show_popover(parent);
+        }
+        return Gdk.EVENT_STOP;
+    }
+}
+
 public class TrayApplet : Budgie.Applet {
     public string uuid { public set; public get; }
     private Carbon.Tray tray;
     private Gtk.EventBox box;
     private Settings? settings;
     private Gtk.Orientation orient;
+    private Gdk.X11.Screen screen;
+
+    // this property prevents the registration of more than one carbontray instance
+    private static string activeUuid = null;
+    private TrayErrorIcon errorIcon;
 
     public TrayApplet(string uuid) {
         Object(uuid: uuid);
@@ -41,65 +89,60 @@ public class TrayApplet : Budgie.Applet {
         box = new Gtk.EventBox();
         add(box);
 
-        hexpand = false;
-        vexpand = false;
-        box.vexpand = false;
-        box.hexpand = false;
-
         settings_schema = "com.solus-project.tray";
         settings_prefix = "/com/solus-project/budgie-panel/instance/tray";
 
         settings = get_applet_settings(uuid);
-        settings.changed.connect(on_settings_change);
+        settings.changed.connect((key) => {
+            if (key == "spacing" && tray != null) {
+                tray.set_spacing(settings.get_int(key));
+            }
+        });
 
-        maybe_integrate_tray();
-    }
+        if (activeUuid == null) {
+            activeUuid = uuid;
+            screen = (Gdk.X11.Screen) get_screen();
 
-    public override bool supports_settings() {
-        return true;
-    }
+            screen.monitors_changed.connect(reintegrate_tray);
+            parent_set.connect((old_parent) => {
+                reintegrate_tray();
+            });
 
-    public override Gtk.Widget? get_settings_ui() {
-        return new TraySettings(get_applet_settings(uuid));
-    }
-
-    void on_settings_change(string key) {
-        if (key != "spacing") {
-            return;
-        }
-        tray.set_spacing(settings.get_int(key));
-    }
-
-    public override void panel_position_changed(Budgie.PanelPosition position) {
-        if (position == Budgie.PanelPosition.LEFT || position == Budgie.PanelPosition.RIGHT) {
-            orient = Gtk.Orientation.VERTICAL;
+            maybe_integrate_tray();
         } else {
-            orient = Gtk.Orientation.HORIZONTAL;
+            // there's already an active tray, create an informative icon with a popover
+            errorIcon = new TrayErrorIcon(box, _("Only one instance of the System Tray can be active at a time."));
+            show_all();
         }
-
-        if (tray == null) {
-            return;
-        }
-
-        tray.unregister();
-        tray.remove_from_container(box);
-        tray = null;
-        maybe_integrate_tray();
     }
 
-    protected void maybe_integrate_tray() {
+    ~TrayApplet() {
+        if (activeUuid == uuid) activeUuid = null;
+    }
+
+    private void reintegrate_tray() {
         if (tray != null) {
-            return;
+            tray.remove_from_container(box);
+            tray.dispose();
+            tray = null;
         }
 
+        if (activeUuid == null || activeUuid == uuid) {
+            maybe_integrate_tray();
+        }
+    }
+
+    private void maybe_integrate_tray() {
         tray = new Carbon.Tray(orient, 24, settings.get_int("spacing"));
 
         if (tray == null) {
-            var label = new Gtk.Label("Tray unavailable");
-            box.add(label);
-            label.show_all();
+            activeUuid = null;
+            errorIcon = new TrayErrorIcon(box, _("The System Tray failed to initialize."));
+            show_all();
             return;
         }
+
+        activeUuid = uuid;
 
         switch (orient) {
         case Gtk.Orientation.HORIZONTAL:
@@ -118,14 +161,29 @@ public class TrayApplet : Budgie.Applet {
 
         tray.add_to_container(box);
         show_all();
-        tray.register((Gdk.X11.Screen) get_screen());
+        tray.register(screen);
+    }
 
-        var win = get_toplevel();
-        if (win == null) {
-            return;
+    public override void panel_position_changed(Budgie.PanelPosition position) {
+        if (position == Budgie.PanelPosition.LEFT || position == Budgie.PanelPosition.RIGHT) {
+            orient = Gtk.Orientation.VERTICAL;
+        } else {
+            orient = Gtk.Orientation.HORIZONTAL;
         }
-        win.queue_draw();
-        queue_resize();
+
+        reintegrate_tray();
+    }
+
+    public override void update_popovers(Budgie.PopoverManager? manager) {
+        if (errorIcon != null) errorIcon.register(manager);
+    }
+
+    public override bool supports_settings() {
+        return true;
+    }
+
+    public override Gtk.Widget? get_settings_ui() {
+        return new TraySettings(get_applet_settings(uuid));
     }
 }
 

--- a/src/applets/tray/carbontray/child.c
+++ b/src/applets/tray/carbontray/child.c
@@ -54,7 +54,7 @@ CarbonChild* carbon_child_new(int size, GdkScreen *screen, Window iconWindow) {
 	int error = gdk_x11_display_error_trap_pop(display);
 
 	if (result == 0) {
-		g_warning("Failed to get icon window attributes");
+		g_info("Failed to populate icon window attributes for tray icon");
 		return NULL;
 	}
 


### PR DESCRIPTION
## Description

The changes within this PR can be summarized in four sections.

### Reintegration
The tray applet will now unregister its carbontray instance when the applet itself is destroyed. In addition, the tray applet will now reintegrate an instance of carbontray within the applet if the parent widget of the applet is changed, or if the monitors connected to the system change their status.

This fixes the following issues:
- Deleting and re-adding the system tray applet causes the applet to become invisible
- Changing the DPI of the connected displays causes glitchy icons
- Turning a screen off and back on causes glitchy and unresponsive icons in HiDPI mode
- Changing the position of the system tray applet causes additional (and unresponsive) nm-applet icons to spawn

### Error Handling
Previously, multiple tray applets could be created across any number of panels, which leads to strange behavior as multiple carbontray instances are fighting for registration. Now, if any additional tray applets are added, they spawn an error icon instead. When this error icon is clicked, it displays a popover with translatable text. This error icon also appears if the tray fails to initialize in any capacity.

### Reasonable DPI
Previously, carbontray's icons would attempt to counteract the GTK scale factor when sizing themselves. This was a behavior taken from na-tray, and I have removed it so as to make icon sizes more consistent and give more control of DPI sizing to GTK.

### Cruft Removal
Some lines of code in TrayApplet.vala surrounding layouts and queueing resizes were completely unnecessary, and were left over from the na-tray version of the applet. These lines have been removed.

### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
