### PR TITLE
Improve Caffeine Applet

### DIFF
--- a/src/applets/caffeine/CaffeineWindow.vala
+++ b/src/applets/caffeine/CaffeineWindow.vala
@@ -23,11 +23,20 @@ public class CaffeineWindow : Budgie.Popover {
         grid.set_row_spacing(6);
         grid.set_column_spacing(12);
 
+        // Prepare label widget
         Gtk.Label caffeine_mode_label = new Gtk.Label(_("Caffeine Mode"));
+        caffeine_mode_label.set_halign(Gtk.Align.START);
         Gtk.Label timer_label = new Gtk.Label(_("Timer (minutes)"));
+        timer_label.set_halign(Gtk.Align.START);
+
+        // Prepare control widget
         mode = new Gtk.Switch();
+        mode.set_halign(Gtk.Align.END);
         var adjustment = new Gtk.Adjustment(0, 0, 1440, 1, 10, 0);
         timer = new Gtk.SpinButton(adjustment, 0, 0);
+        timer.set_halign(Gtk.Align.END);
+
+        // Attach widgets
         grid.attach(caffeine_mode_label, 0, 0);
         grid.attach(timer_label, 0, 1);
         grid.attach(mode, 1, 0);

--- a/src/daemon/settings.vala
+++ b/src/daemon/settings.vala
@@ -326,14 +326,26 @@ public class SettingsManager {
             change_brightness((enabled) ? set_brightness : default_brightness);
         }
 
+		var time = wm_settings.get_int("caffeine-mode-timer"); // Get our timer number
+		if (enabled && (time > 0)) { // If Caffeine Mode is enabled and we'll turn it off in a certain amount of time
+			Timeout.add_seconds(time * 60, this.do_disable, Priority.HIGH);
+			Timeout.add_seconds(60, () => {
+				var countdown = wm_settings.get_int("caffeine-mode-timer");
+				if (countdown != 0) {
+					countdown -= 1;
+					wm_settings.set_int("caffeine-mode-timer", countdown);
+				}
+
+				return (countdown != 0);
+			});
+		}
+
         if (wm_settings.get_boolean("caffeine-mode-notification") && !disable_notification && !temporary_notification_disabled && Notify.is_initted()) { // Should show a notification
             string title = (enabled) ? _("Turned on Caffeine Boost") : _("Turned off Caffeine Boost");
             string body = "";
             string icon = (enabled) ? caffeine_full_cup : caffeine_empty_cup;
 
-            var time = wm_settings.get_int("caffeine-mode-timer"); // Get our timer number
-
-            if (enabled && (time > 0)) { // If Caffeine Mode is enabled and we'll turn it off in a certain amount of time
+            if (enabled && (time > 0)) {
                 var duration = _("Will turn off in a minute");
 
                 if (time > 1) { // use plural
@@ -341,7 +353,6 @@ public class SettingsManager {
                 }
 
                 body = duration;
-                Timeout.add_seconds(time * 60, this.do_disable, Priority.HIGH);
             }
 
             if (this.caffeine_notification == null) { // Caffeine Notification not yet created


### PR DESCRIPTION
## Description
Make timer label as countdown (fixes #1747), change widget alignment, and
fixes timer not working if caffeine notification is turn off.

### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
