### PR TITLE
Additional cleanup in Vala and vapi files, add editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# http://editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{c,h,vala,vapi}]
+indent_style = tab
+tab_width = 4

--- a/src/abomination/abomination.vala
+++ b/src/abomination/abomination.vala
@@ -15,13 +15,13 @@ namespace Budgie {
 	 */
 	public class Abomination : GLib.Object {
 		private Budgie.AppSystem? app_system = null;
-		private GLib.Settings? color_settings = null;
-		private GLib.Settings? wm_settings = null;
+		private Settings? color_settings = null;
+		private Settings? wm_settings = null;
 		private bool original_night_light_setting = false;
 		private bool should_disable_on_fullscreen = false;
-		public HashTable<string?, Wnck.Window?> fullscreen_windows; // fullscreen_windows is a list of fullscreen windows based on their name and respective Wnck.Window
-		public HashTable<string?, Array<AbominationRunningApp>?> running_apps; // running_apps is a list of running apps based on the group name and AbominationRunningApp
-		public HashTable<ulong?, AbominationRunningApp?> running_apps_id; // running_apps_ids is a list of apps based on the window id and AbominationRunningApp
+		public HashTable<string?,Wnck.Window?> fullscreen_windows; // fullscreen_windows is a list of fullscreen windows based on their name and respective Wnck.Window
+		public HashTable<string?,Array<AbominationRunningApp>?> running_apps; // running_apps is a list of running apps based on the group name and AbominationRunningApp
+		public HashTable<ulong?,AbominationRunningApp?> running_apps_id; // running_apps_ids is a list of apps based on the window id and AbominationRunningApp
 		private Wnck.Screen screen = null;
 
 		/**
@@ -34,12 +34,12 @@ namespace Budgie {
 
 		public Abomination() {
 			app_system = new Budgie.AppSystem();
-			color_settings = new GLib.Settings("org.gnome.settings-daemon.plugins.color");
-			wm_settings = new GLib.Settings("com.solus-project.budgie-wm");
+			color_settings = new Settings("org.gnome.settings-daemon.plugins.color");
+			wm_settings = new Settings("com.solus-project.budgie-wm");
 
-			fullscreen_windows = new HashTable<string?, Wnck.Window?>(str_hash, str_equal);
-			running_apps = new HashTable<string?, Array<AbominationRunningApp>?>(str_hash, str_equal);
-			running_apps_id = new HashTable<ulong?, AbominationRunningApp?>(int_hash, int_equal);
+			fullscreen_windows = new HashTable<string?,Wnck.Window?>(str_hash, str_equal);
+			running_apps = new HashTable<string?,Array<AbominationRunningApp>?>(str_hash, str_equal);
+			running_apps_id = new HashTable<ulong?,AbominationRunningApp?>(int_hash, int_equal);
 			screen = Wnck.Screen.get_default();
 
 			if (color_settings != null) { // gsd colors plugin schema defined
@@ -69,8 +69,8 @@ namespace Budgie {
 					Array<AbominationRunningApp> group_apps = running_apps.get(group_name); // Get the apps associated with the group name
 
 					if ((group_apps != null) && (group_apps.length > 0)) { // If there are apps (and this exists)
-						for (int i = 0; i < group_apps.length; i++)	 {
-							AbominationRunningApp app =	 group_apps.index(i);
+						for (int i = 0; i < group_apps.length; i++) {
+							AbominationRunningApp app = group_apps.index(i);
 							running_apps_id.steal(app.id); // Remove from running_apps_id
 						}
 
@@ -296,7 +296,6 @@ namespace Budgie {
 		/**
 		 * invalid_window will check if the provided window is our current window
 		 * If the provided window is our current window, update to any new window in the class group, update our name, etc.
-		 * 
 		 */
 		public void invalidate_window(Wnck.Window window) {
 			if (this.window == null || window == null) {
@@ -359,7 +358,7 @@ namespace Budgie {
 				string old_icon = this.icon;
 				update_icon();
 
-				if (this.icon !=  old_icon) { // Actually changed
+				if (this.icon != old_icon) { // Actually changed
 					icon_changed(this.icon);
 				}
 			});

--- a/src/applets/budgie-menu/BudgieMenu.vala
+++ b/src/applets/budgie-menu/BudgieMenu.vala
@@ -1,8 +1,8 @@
 /*
  * This file is part of budgie-desktop
- * 
+ *
  * Copyright © 2015-2019 Budgie Desktop Developers
- * 
+ *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
@@ -15,7 +15,7 @@ public class BudgieMenu : Budgie.Plugin, Peas.ExtensionBase {
 	}
 }
 
-[GtkTemplate (ui = "/com/solus-project/budgie-menu/settings.ui")]
+[GtkTemplate (ui="/com/solus-project/budgie-menu/settings.ui")]
 public class BudgieMenuSettings : Gtk.Grid {
 	[GtkChild]
 	private Gtk.Switch? switch_menu_label;
@@ -117,7 +117,7 @@ public class BudgieMenuApplet : Budgie.Applet {
 		popover = new BudgieMenuWindow(settings, widget);
 		popover.bind_property("visible", widget, "active");
 
-		widget.button_press_event.connect((e)=> {
+		widget.button_press_event.connect((e) => {
 			if (e.button != 1) {
 				return Gdk.EVENT_PROPAGATE;
 			}
@@ -144,14 +144,14 @@ public class BudgieMenuApplet : Budgie.Applet {
 		on_settings_changed("menu-label");
 
 		/* Potentially reload icon on pixel size jumps */
-		panel_size_changed.connect((p,i,s)=> {
+		panel_size_changed.connect((p, i, s) => {
 			if (this.pixel_size != i) {
 				this.pixel_size = (int)i;
 				this.on_settings_changed("menu-icon");
 			}
 		});
 
-		popover.key_release_event.connect((e)=> {
+		popover.key_release_event.connect((e) => {
 			if (e.keyval == Gdk.Key.Escape) {
 				popover.hide();
 			}

--- a/src/applets/budgie-menu/BudgieMenuButtons.vala
+++ b/src/applets/budgie-menu/BudgieMenuButtons.vala
@@ -1,8 +1,8 @@
 /*
  * This file is part of budgie-desktop
- * 
+ *
  * Copyright © 2015-2019 Budgie Desktop Developers
- * 
+ *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
@@ -123,7 +123,7 @@ public class MenuButton : Gtk.Button {
 		if (found != null) {
 			score += 20 + found.length;
 		}
-		score += GLib.strcmp(name, term);
+		score += strcmp(name, term);
 		return score;
 	}
 }

--- a/src/applets/budgie-menu/BudgieMenuWindow.vala
+++ b/src/applets/budgie-menu/BudgieMenuWindow.vala
@@ -194,7 +194,7 @@ public class BudgieMenuWindow : Budgie.Popover {
 		SignalHandler.disconnect_by_func(tree, (void*)refresh_tree, this);
 		this.tree = null;
 
-		Idle.add(()=> {
+		Idle.add(() => {
 			load_menus(null);
 			content.invalidate_headers();
 			content.invalidate_filter();
@@ -250,7 +250,7 @@ public class BudgieMenuWindow : Budgie.Popover {
 				return;
 			}
 			/* Think of deferred routines.. */
-			Idle.add(()=> {
+			Idle.add(() => {
 				tree.changed.connect(refresh_tree);
 				return false;
 			});
@@ -298,7 +298,7 @@ public class BudgieMenuWindow : Budgie.Popover {
 					category_buttons.insert(dir.get_name(), btn); // Add the button for the desktop file path
 
 					// Ensures we find the correct button
-					btn.toggled.connect(()=>{
+					btn.toggled.connect(() => {
 						update_category(btn);
 					});
 				}
@@ -338,7 +338,7 @@ public class BudgieMenuWindow : Budgie.Popover {
 					var app_id = appinfo.get_id();
 
 					if (root.get_desktop_file_path().has_suffix("X-GNOME-Sundry.directory")) { // If we're iterating over desktop entries in Sundry
-						if (other_tree != null)	 {
+						if (other_tree != null) {
 							use_root = other_tree;
 						}
 					}
@@ -346,7 +346,7 @@ public class BudgieMenuWindow : Budgie.Popover {
 					if (!menu_buttons.contains(app_id)) { // If we haven't already added this button
 						var btn = new MenuButton(appinfo, use_root, icon_size);
 
-						btn.clicked.connect(()=> {
+						btn.clicked.connect(() => {
 							hide();
 							launch_app(btn.info);
 						});
@@ -630,13 +630,13 @@ public class BudgieMenuWindow : Budgie.Popover {
 	protected void launch_app(DesktopAppInfo info) {
 		hide();
 		// Do it on the idle thread to make sure we don't have focus wars
-		Idle.add(()=> {
+		Idle.add(() => {
 			try {
 				/*
 				 appinfo.launch has difficulty running pkexec
 				 based apps so lets spawn an async process instead
 				 */
-				var commandline =  info.get_commandline();
+				var commandline = info.get_commandline();
 				string[] spawn_args = {};
 				const string checkstr = "pkexec";
 				if (commandline.contains(checkstr)) {
@@ -677,7 +677,7 @@ public class BudgieMenuWindow : Budgie.Popover {
 		content_scroll.get_vadjustment().set_value(0);
 		categories_scroll.get_vadjustment().set_value(0);
 		categories.sensitive = true;
-		Idle.add(()=> {
+		Idle.add(() => {
 			/* grab focus when we're not busy, ensuring it works.. */
 			search_entry.grab_focus();
 			return false;

--- a/src/applets/budgie-menu/IconChooser.vala
+++ b/src/applets/budgie-menu/IconChooser.vala
@@ -1,8 +1,8 @@
 /*
  * This file is part of budgie-desktop
- * 
+ *
  * Copyright © 2017-2019 Budgie Desktop Developers
- * 
+ *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or

--- a/src/applets/caffeine/CaffeineApplet.vala
+++ b/src/applets/caffeine/CaffeineApplet.vala
@@ -1,4 +1,3 @@
-
 /*
  * This file is part of budgie-desktop
  *
@@ -53,7 +52,7 @@ namespace Caffeine {
 			});
 
 			interface_settings.changed["icon-theme"].connect_after(() => {
-				Timeout.add(200, ()=> {
+				Timeout.add(200, () => {
 					set_caffeine_icons(); // Update our Caffeine Icons
 					update_icon(); // Update the icon
 					return false;
@@ -61,7 +60,7 @@ namespace Caffeine {
 			});
 
 			// On click icon
-			event_box.button_press_event.connect((e)=> {
+			event_box.button_press_event.connect((e) => {
 				switch (e.button) {
 				case 1:
 					if (popover.get_visible()) {

--- a/src/applets/caffeine/CaffeineSettings.vala
+++ b/src/applets/caffeine/CaffeineSettings.vala
@@ -1,5 +1,5 @@
 namespace Caffeine {
-	[GtkTemplate (ui = "/com/solus-project/caffeine/settings.ui")]
+	[GtkTemplate (ui="/com/solus-project/caffeine/settings.ui")]
 	public class AppletSettings : Gtk.Grid {
 		private Settings? settings = null;
 		private Settings? wm_settings = null;

--- a/src/applets/caffeine/CaffeineWindow.vala
+++ b/src/applets/caffeine/CaffeineWindow.vala
@@ -56,7 +56,7 @@ namespace Caffeine {
 				SignalHandler.unblock(timer, timer_id);
 			});
 
-			mode_id = mode.notify["active"].connect (() => { // On active change
+			mode_id = mode.notify["active"].connect(() => { // On active change
 				SignalHandler.block(mode, mode_id); // Block to prevent update on set_caffeine_mode schema change
 				timer.sensitive = !mode.active; // Set timer sensitivity
 				settings.set_boolean("caffeine-mode", mode.active); // Update our caffeine-mode WM setting

--- a/src/applets/clock/ClockApplet.vala
+++ b/src/applets/clock/ClockApplet.vala
@@ -149,7 +149,7 @@ public class ClockApplet : Budgie.Applet {
 		menu.pack_start(time_button, false, false, 0);
 		menu.pack_start(cal_button, false, false, 0);
 		var sub_button = this.new_directional_button(_("Preferences"), Gtk.PositionType.RIGHT);
-		sub_button.clicked.connect(()=> { stack.set_visible_child_name("prefs"); });
+		sub_button.clicked.connect(() => { stack.set_visible_child_name("prefs"); });
 		menu.pack_end(sub_button, false, false, 2);
 
 		stack.add_named(menu, "root");
@@ -172,7 +172,7 @@ public class ClockApplet : Budgie.Applet {
 		clock_format = new Gtk.CheckButton.with_label(_("Use 24 hour time"));
 		clock_format.get_child().set_property("margin-start", 8);
 
-		check_id = clock_format.toggled.connect_after(()=> {
+		check_id = clock_format.toggled.connect_after(() => {
 			ClockFormat f = (ClockFormat)settings.get_enum("clock-format");
 			ClockFormat newf = f == ClockFormat.TWELVE ? ClockFormat.TWENTYFOUR : ClockFormat.TWELVE;
 			this.settings.set_enum("clock-format", newf);
@@ -180,7 +180,7 @@ public class ClockApplet : Budgie.Applet {
 
 		// pack page2
 		sub_button = this.new_directional_button(_("Preferences"), Gtk.PositionType.LEFT);
-		sub_button.clicked.connect(()=> { stack.set_visible_child_name("root"); });
+		sub_button.clicked.connect(() => { stack.set_visible_child_name("root"); });
 		menu.pack_start(sub_button, false, false, 0);
 		menu.pack_start(new Gtk.Separator(Gtk.Orientation.HORIZONTAL), false, false, 2);
 		menu.pack_start(check_date, false, false, 0);
@@ -190,11 +190,11 @@ public class ClockApplet : Budgie.Applet {
 
 
 		// Always open to the root page
-		popover.closed.connect(()=> {
+		popover.closed.connect(() => {
 			stack.set_visible_child_name("root");
 		});
 
-		widget.button_press_event.connect((e)=> {
+		widget.button_press_event.connect((e) => {
 			if (e.button != 1) {
 				return Gdk.EVENT_PROPAGATE;
 			}
@@ -206,7 +206,7 @@ public class ClockApplet : Budgie.Applet {
 			return Gdk.EVENT_STOP;
 		});
 
-		Timeout.add_seconds_full(GLib.Priority.LOW, 1, update_clock);
+		Timeout.add_seconds_full(Priority.LOW, 1, update_clock);
 
 		settings.changed.connect(on_settings_change);
 
@@ -350,7 +350,7 @@ public class ClockApplet : Budgie.Applet {
 				format += ":%S";
 			}
 		}
-	
+
 		if (ampm) {
 			format += " %p";
 		}

--- a/src/applets/icon-tasklist/ButtonWrapper.vala
+++ b/src/applets/icon-tasklist/ButtonWrapper.vala
@@ -54,7 +54,7 @@ public class ButtonWrapper : Gtk.Revealer {
 			this.set_transition_type(Gtk.RevealerTransitionType.SLIDE_UP);
 		}
 
-		this.notify["child-revealed"].connect_after(()=> {
+		this.notify["child-revealed"].connect_after(() => {
 			this.hide();
 			this.destroy();
 		});

--- a/src/applets/icon-tasklist/DesktopHelper.vala
+++ b/src/applets/icon-tasklist/DesktopHelper.vala
@@ -8,12 +8,12 @@
  * the Free Software Foundation; either version 2 of the License, or
  * (at your option) any later version.
  */
- 
+
 /**
  * Trivial helper for IconTasklist - i.e. desktop lookups
  */
 public class DesktopHelper : GLib.Object {
-	private GLib.Settings? settings = null;
+	private Settings? settings = null;
 	private Wnck.Screen? screen = null;
 	private Gtk.Box? icon_layout = null;
 
@@ -29,7 +29,7 @@ public class DesktopHelper : GLib.Object {
 	/**
 	 * Handle initial bootstrap of the desktop helper
 	 */
-	public DesktopHelper(GLib.Settings? settings, Gtk.Box? icon_layout) {
+	public DesktopHelper(Settings? settings, Gtk.Box? icon_layout) {
 		/* Stash privates */
 		this.settings = settings;
 		this.icon_layout = icon_layout;
@@ -67,8 +67,8 @@ public class DesktopHelper : GLib.Object {
 	/**
 	 * Grab the list of windows stacked for the given class_group
 	 */
-	public GLib.List<unowned Wnck.Window> get_stacked_for_classgroup(Wnck.ClassGroup class_group) {
-		GLib.List<unowned Wnck.Window> list = new GLib.List<unowned Wnck.Window>();
+	public List<unowned Wnck.Window> get_stacked_for_classgroup(Wnck.ClassGroup class_group) {
+		List<unowned Wnck.Window> list = new List<unowned Wnck.Window>();
 		screen.get_windows_stacked().foreach((window) => {
 			if (window.get_class_group() == class_group && !window.is_skip_tasklist()) {
 				var workspace = window.get_workspace();

--- a/src/applets/icon-tasklist/Icon.vala
+++ b/src/applets/icon-tasklist/Icon.vala
@@ -108,7 +108,7 @@ public class Icon : Gtk.Image {
 			};
 		}
 
-		attention_animation.start((a)=> {
+		attention_animation.start((a) => {
 			animate_attention(null);
 		});
 	}
@@ -154,14 +154,14 @@ public class Icon : Gtk.Image {
 			this.icon_opacity = 0.3;
 		});
 
-		GLib.Timeout.add(700, () => {
+		Timeout.add(700, () => {
 			if (!waiting) {
 				wait_animation.stop();
 				wait_animation1.stop();
 				this.icon_opacity = 1.0;
 				return false;
 			}
-			wait_animation1.start((a)=> {
+			wait_animation1.start((a) => {
 				this.icon_opacity = 1.0;
 				animate_wait();
 			});
@@ -192,7 +192,7 @@ public class Icon : Gtk.Image {
 			}
 		};
 
-		launch_animation.start((a)=> {
+		launch_animation.start((a) => {
 			this.bounce = 0.0;
 		});
 	}

--- a/src/applets/icon-tasklist/IconButton.vala
+++ b/src/applets/icon-tasklist/IconButton.vala
@@ -10,8 +10,8 @@
  */
 
 const double DEFAULT_OPACITY = 0.1;
-const int INDICATOR_SIZE	 = 2;
-const int INDICATOR_SPACING	 = 1;
+const int INDICATOR_SIZE = 2;
+const int INDICATOR_SPACING = 1;
 const int INACTIVE_INDICATOR_SPACING = 2;
 
 /**
@@ -23,10 +23,10 @@ public class IconButton : Gtk.ToggleButton {
 	private Budgie.AbominationRunningApp? first_app = null;
 	private Budgie.IconPopover? popover = null;
 	private Wnck.Screen? screen = null;
-	private GLib.Settings? settings = null;
-	private Wnck.Window? window = null;			 // This will always be null if grouping is enabled
+	private Settings? settings = null;
+	private Wnck.Window? window = null; // This will always be null if grouping is enabled
 	private Wnck.ClassGroup? class_group = null; // This will always be null if grouping is disabled
-	private GLib.DesktopAppInfo? app_info = null;
+	private DesktopAppInfo? app_info = null;
 	private int window_count = 0;
 	public Icon icon;
 	private Gtk.Allocation definite_allocation;
@@ -43,7 +43,7 @@ public class IconButton : Gtk.ToggleButton {
 	public unowned DesktopHelper? desktop_helper { public set; public get; default = null; }
 	public unowned Budgie.PopoverManager? popover_manager { public set; public get; default = null; }
 
-	public IconButton(Budgie.AppSystem? appsys, GLib.Settings? c_settings, DesktopHelper? helper, Budgie.PopoverManager? manager, GLib.DesktopAppInfo info, bool pinned) {
+	public IconButton(Budgie.AppSystem? appsys, Settings? c_settings, DesktopHelper? helper, Budgie.PopoverManager? manager, DesktopAppInfo info, bool pinned) {
 		Object(app_system: appsys, desktop_helper: helper, popover_manager: manager);
 		this.settings = c_settings;
 		this.app_info = info;
@@ -59,7 +59,7 @@ public class IconButton : Gtk.ToggleButton {
 		}
 	}
 
-	public IconButton.from_window(Budgie.AppSystem? appsys, GLib.Settings? c_settings, DesktopHelper? helper, Budgie.PopoverManager? manager, Wnck.Window window, GLib.DesktopAppInfo? info, bool pinned = false) {
+	public IconButton.from_window(Budgie.AppSystem? appsys, Settings? c_settings, DesktopHelper? helper, Budgie.PopoverManager? manager, Wnck.Window window, DesktopAppInfo? info, bool pinned = false) {
 		Object(app_system: appsys, desktop_helper: helper, popover_manager: manager);
 		this.settings = c_settings;
 		this.app_info = info;
@@ -94,7 +94,7 @@ public class IconButton : Gtk.ToggleButton {
 		this.set_wnck_window(window);
 	}
 
-	public IconButton.from_group(Budgie.AppSystem? appsys, GLib.Settings? c_settings, DesktopHelper? helper, Budgie.PopoverManager? manager, Wnck.ClassGroup class_group, GLib.DesktopAppInfo? info) {
+	public IconButton.from_group(Budgie.AppSystem? appsys, Settings? c_settings, DesktopHelper? helper, Budgie.PopoverManager? manager, Wnck.ClassGroup class_group, DesktopAppInfo? info) {
 		Object(app_system: appsys, desktop_helper: helper, popover_manager: manager);
 
 		this.settings = c_settings;
@@ -164,7 +164,7 @@ public class IconButton : Gtk.ToggleButton {
 			}
 		});
 
-		drag_data_get.connect((widget, context, selection_data, info, time)=> {
+		drag_data_get.connect((widget, context, selection_data, info, time) => {
 			string id = "";
 			if (this.is_from_window) { // If this is from a window
 				if (this.pinned && this.originally_pinned) { // Has been pinned from the start
@@ -523,7 +523,7 @@ public class IconButton : Gtk.ToggleButton {
 
 		try {
 			app_info.launch(null, launch_context);
-		} catch (GLib.Error e) {
+		} catch (Error e) {
 			warning(e.message);
 		}
 	}
@@ -568,14 +568,14 @@ public class IconButton : Gtk.ToggleButton {
 	/**
 	 * Handle startup notification, set our own ID to the ID selected
 	 */
-	private void on_launched(GLib.AppInfo info, Variant v) {
-		GLib.Variant? elem;
+	private void on_launched(AppInfo info, Variant v) {
+		Variant? elem;
 
 		var iter = v.iterator();
 
 		while ((elem = iter.next_value()) != null) {
 			string? key = null;
-			GLib.Variant? val = null;
+			Variant? val = null;
 
 			elem.get("{sv}", out key, out val);
 
@@ -583,7 +583,7 @@ public class IconButton : Gtk.ToggleButton {
 				continue;
 			}
 
-			if (!val.is_of_type(GLib.VariantType.STRING)) {
+			if (!val.is_of_type(VariantType.STRING)) {
 				continue;
 			}
 
@@ -605,12 +605,12 @@ public class IconButton : Gtk.ToggleButton {
 		int y = definite_allocation.y;
 		int width = definite_allocation.width;
 		int height = definite_allocation.height;
-		GLib.List<unowned Wnck.Window> windows;
+		List<unowned Wnck.Window> windows;
 
 		if (class_group != null) {
 			windows = class_group.get_windows().copy();
 		} else {
-			windows = new GLib.List<unowned Wnck.Window>();
+			windows = new List<unowned Wnck.Window>();
 			windows.insert(this.window, 0);
 		}
 
@@ -672,12 +672,12 @@ public class IconButton : Gtk.ToggleButton {
 		int y = definite_allocation.y;
 		int width = definite_allocation.width;
 		int height = definite_allocation.height;
-		GLib.List<unowned Wnck.Window> windows;
+		List<unowned Wnck.Window> windows;
 
 		if (class_group != null) {
 			windows = class_group.get_windows().copy();
 		} else {
-			windows = new GLib.List<unowned Wnck.Window>();
+			windows = new List<unowned Wnck.Window>();
 			windows.insert(this.window, 0);
 		}
 
@@ -780,7 +780,7 @@ public class IconButton : Gtk.ToggleButton {
 					case Budgie.PanelPosition.RIGHT:
 						int to = 0;
 						if (counter == count-1) {
-							to = y + height; 
+							to = y + height;
 						} else {
 							to = previous_y+(height/count);
 						}
@@ -789,7 +789,7 @@ public class IconButton : Gtk.ToggleButton {
 					default:
 						int to = 0;
 						if (counter == count-1) {
-							to = x + width; 
+							to = x + width;
 						} else {
 							to = previous_x+(width/count);
 						}
@@ -932,7 +932,7 @@ public class IconButton : Gtk.ToggleButton {
 		} else if (event.button == 1) { // Left click
 			handle_launch_clicks(event, false);
 		} else if (event.button == 2) { // Middle click
-			GLib.List<unowned Wnck.Window> windows;
+			List<unowned Wnck.Window> windows;
 			bool middle_click_create_new_instance = false;
 
 			if (this.settings != null) { // Settings defined
@@ -943,7 +943,7 @@ public class IconButton : Gtk.ToggleButton {
 				if (class_group != null) {
 					windows = class_group.get_windows().copy();
 				} else {
-					windows = new GLib.List<unowned Wnck.Window>();
+					windows = new List<unowned Wnck.Window>();
 				}
 
 				if (windows.length() == 0) {
@@ -1035,7 +1035,7 @@ public class IconButton : Gtk.ToggleButton {
 			return Gdk.EVENT_STOP;
 		}
 
-		if (GLib.get_monotonic_time() - last_scroll_time < 300000) {
+		if (get_monotonic_time() - last_scroll_time < 300000) {
 			return Gdk.EVENT_STOP;
 		}
 
@@ -1092,10 +1092,10 @@ public class IconButton : Gtk.ToggleButton {
 					target_window.unminimize(event.time);
 				}
 
-				last_scroll_time = GLib.get_monotonic_time();
+				last_scroll_time = get_monotonic_time();
 			}
 		} else if (ids_length == 1) { // Only has one window and scrolling up
-			var id = ids.nth_data(0);  // Get id at 0
+			var id = ids.nth_data(0); // Get id at 0
 			target_window = Wnck.Window.@get(id);
 
 			if (target_window != null) {
@@ -1109,14 +1109,14 @@ public class IconButton : Gtk.ToggleButton {
 					target_window.minimize();
 				}
 
-				last_scroll_time = GLib.get_monotonic_time();
+				last_scroll_time = get_monotonic_time();
 			}
 		}
 
 		return Gdk.EVENT_STOP;
 	}
 
-	public GLib.DesktopAppInfo? get_appinfo() {
+	public DesktopAppInfo? get_appinfo() {
 		return this.app_info;
 	}
 

--- a/src/applets/icon-tasklist/IconPopover.vala
+++ b/src/applets/icon-tasklist/IconPopover.vala
@@ -68,7 +68,7 @@ namespace Budgie {
 			 * Data / Logic
 			 */
 			this.window_id_to_name = new HashTable<ulong?,string?>(int_hash, int_equal);
-			this.window_id_to_controls = new HashTable<ulong?, Budgie.IconPopoverItem?>(int_hash, int_equal);
+			this.window_id_to_controls = new HashTable<ulong?,Budgie.IconPopoverItem?>(int_hash, int_equal);
 			this.workspace_items = new List<Budgie.IconPopoverItem>();
 			create_images();
 
@@ -402,7 +402,7 @@ namespace Budgie {
 
 						for (int i = 0; i < workspaces_to_remove; i++) {
 							Budgie.IconPopoverItem child = workspace_items.nth_data(i);
-	
+
 							if (child != null) {
 								this.actions_view.remove(child);
 								workspace_items.remove(child);

--- a/src/applets/icon-tasklist/IconTasklistApplet.vala
+++ b/src/applets/icon-tasklist/IconTasklistApplet.vala
@@ -15,7 +15,7 @@ public class IconTasklist : Budgie.Plugin, Peas.ExtensionBase {
 	}
 }
 
-[GtkTemplate (ui = "/com/solus-project/icon-tasklist/settings.ui")]
+[GtkTemplate (ui="/com/solus-project/icon-tasklist/settings.ui")]
 public class IconTasklistSettings : Gtk.Grid {
 	[GtkChild]
 	private Gtk.Switch? switch_grouping;
@@ -38,9 +38,9 @@ public class IconTasklistSettings : Gtk.Grid {
 	[GtkChild]
 	private Gtk.Switch? switch_require_double_click_to_launch_new_instance;
 
-	private GLib.Settings? settings;
+	private Settings? settings;
 
-	public IconTasklistSettings(GLib.Settings? settings) {
+	public IconTasklistSettings(Settings? settings) {
 		this.settings = settings;
 		settings.bind("grouping", switch_grouping, "active", SettingsBindFlags.DEFAULT);
 		settings.bind("restrict-to-workspace", switch_restrict, "active", SettingsBindFlags.DEFAULT);
@@ -55,9 +55,9 @@ public class IconTasklistSettings : Gtk.Grid {
 public class IconTasklistApplet : Budgie.Applet {
 	private Budgie.Abomination? abomination = null;
 	private Wnck.Screen? wnck_screen = null;
-	private GLib.Settings? settings = null;
-	private GLib.HashTable<string, IconButton> buttons;
-	private GLib.HashTable<string, string> id_map;
+	private Settings? settings = null;
+	private HashTable<string,IconButton> buttons;
+	private HashTable<string,string> id_map;
 	private Gtk.Box? main_layout = null;
 	private bool grouping = true;
 	private bool restrict_to_workspace = false;
@@ -79,7 +79,7 @@ public class IconTasklistApplet : Budgie.Applet {
 	}
 
 	public IconTasklistApplet(string uuid) {
-		GLib.Object(uuid: uuid);
+		Object(uuid: uuid);
 
 		/* Get our settings working first */
 		settings_schema = "com.solus-project.icon-tasklist";
@@ -87,8 +87,8 @@ public class IconTasklistApplet : Budgie.Applet {
 		settings = this.get_applet_settings(uuid);
 
 		/* Somewhere to store the window mappings */
-		buttons = new GLib.HashTable<string, IconButton>(str_hash, str_equal);
-		id_map = new GLib.HashTable<string, string>(str_hash, str_equal);
+		buttons = new HashTable<string,IconButton>(str_hash, str_equal);
+		id_map = new HashTable<string,string>(str_hash, str_equal);
 		main_layout = new Gtk.Box(Gtk.Orientation.HORIZONTAL, 0);
 
 		/* Initial bootstrap of helpers */
@@ -106,7 +106,7 @@ public class IconTasklistApplet : Budgie.Applet {
 		main_layout.drag_data_received.connect(on_drag_data_received);
 
 		app_system.app_launched.connect((desktop_file) => {
-			GLib.DesktopAppInfo? info = new GLib.DesktopAppInfo.from_filename(desktop_file);
+			DesktopAppInfo? info = new DesktopAppInfo.from_filename(desktop_file);
 			if (info == null) {
 				return;
 			}
@@ -124,7 +124,7 @@ public class IconTasklistApplet : Budgie.Applet {
 		on_settings_changed("lock-icons");
 		on_settings_changed("only-pinned");
 
-		GLib.Timeout.add(1000, () => {
+		Timeout.add(1000, () => {
 			connect_wnck_signals();
 			on_active_window_changed(null);
 			return false;
@@ -138,7 +138,7 @@ public class IconTasklistApplet : Budgie.Applet {
 		string[] pinned = settings.get_strv("pinned-launchers");
 
 		foreach (string launcher in pinned) {
-			GLib.DesktopAppInfo? info = new GLib.DesktopAppInfo(launcher);
+			DesktopAppInfo? info = new DesktopAppInfo(launcher);
 			if (info == null) {
 				continue;
 			}
@@ -200,7 +200,7 @@ public class IconTasklistApplet : Budgie.Applet {
 		switch (key) {
 			case "grouping":
 				this.grouping = settings.get_boolean(key);
-				GLib.Idle.add(() => {
+				Idle.add(() => {
 					rebuild_items();
 					return false;
 				});
@@ -260,7 +260,7 @@ public class IconTasklistApplet : Budgie.Applet {
 			app_id = app_id.split("://")[1];
 			app_id = app_id.strip();
 
-			GLib.DesktopAppInfo? info = new GLib.DesktopAppInfo.from_filename(app_id);
+			DesktopAppInfo? info = new DesktopAppInfo.from_filename(app_id);
 			if (info == null) {
 				return;
 			}
@@ -380,7 +380,7 @@ public class IconTasklistApplet : Budgie.Applet {
 			return;
 		}
 
-		GLib.DesktopAppInfo? app_info = first_app.app;
+		DesktopAppInfo? app_info = first_app.app;
 
 		string app_id = (app_info == null) ? "%s".printf(group_name) : app_info.get_id();
 		app_id = app_id.strip();
@@ -393,7 +393,7 @@ public class IconTasklistApplet : Budgie.Applet {
 			return;
 		}
 
-		IconButton button = new IconButton.from_group(this.app_system, this.settings,this.desktop_helper, this.manager, first_app.group_object, app_info);
+		IconButton button = new IconButton.from_group(this.app_system, this.settings, this.desktop_helper, this.manager, first_app.group_object, app_info);
 		ButtonWrapper wrapper = new ButtonWrapper(button);
 		wrapper.orient = this.get_orientation();
 
@@ -536,7 +536,7 @@ public class IconTasklistApplet : Budgie.Applet {
 	void set_icons_size() {
 		Wnck.set_default_icon_size(this.desktop_helper.icon_size);
 
-		Idle.add(()=> {
+		Idle.add(() => {
 			buttons.foreach((id, button) => {
 				button.update_icon();
 			});

--- a/src/applets/icon-tasklist/animation.vala
+++ b/src/applets/icon-tasklist/animation.vala
@@ -19,26 +19,26 @@ namespace BudgieTaskList {
 	/** Animate a GObject property */
 	public struct PropChange {
 		string property; /**<GObject property name */
-		Value old;		 /**<Value pre-animation */
-		Value @new;		 /**<Target value for end of animation */
+		Value old; /**<Value pre-animation */
+		Value @new; /**<Target value for end of animation */
 	}
 
 	/**
 	* Utility to struct to enable easier animations
-	* Inspired by Clutter. 
+	* Inspired by Clutter.
 	*/
 	[Compact]
-	public class Animation : Object {
-		public int64 start_time;		   /**<Start time (microseconds) of animation */
-		public int64 length;			   /**<Length of animation in microseconds */
-		public unowned TweenFunc tween;	   /**<Tween function to use for property changes */
-		public PropChange[] changes;	  /**<Group of properties to change in this animation */
+	public class Animation : GLib.Object {
+		public int64 start_time; /**<Start time (microseconds) of animation */
+		public int64 length; /**<Length of animation in microseconds */
+		public unowned TweenFunc tween; /**<Tween function to use for property changes */
+		public PropChange[] changes; /**<Group of properties to change in this animation */
 		public unowned Gtk.Widget widget;/**<Rendering widget that owns the Gdk.FrameClock */
-		public GLib.Object? object;		   /**<Widget to apply property changes to */
-		public uint id;					   /**<Idle source ID */
-		public bool can_anim;			   /**<Whether we can animate ?*/
-		public int64 elapsed;			  /**<Elapsed time */
-		public bool no_reset;			  /**<Used sometimes for switching an animation*/
+		public Object? object; /**<Widget to apply property changes to */
+		public uint id; /**<Idle source ID */
+		public bool can_anim; /**<Whether we can animate ?*/
+		public int64 elapsed; /**<Elapsed time */
+		public bool no_reset; /**<Used sometimes for switching an animation*/
 		private AnimCompletionFunc compl;
 
 		private bool tick_callback(Gtk.Widget widget, Gdk.FrameClock frame) {

--- a/src/applets/keyboard-layout/KeyboardLayoutApplet.vala
+++ b/src/applets/keyboard-layout/KeyboardLayoutApplet.vala
@@ -45,7 +45,7 @@ class AppletIBusManager : GLib.Object {
 	public void do_init() {
 		this.engines = new HashTable<string,weak IBus.EngineDesc>(str_hash, str_equal);
 		if (Environment.find_program_in_path("ibus-daemon") == null) {
-			GLib.message("ibus-daemon unsupported on this system");
+			message("ibus-daemon unsupported on this system");
 			this.ibus_available = false;
 			this.ready();
 			return;
@@ -74,7 +74,7 @@ class AppletIBusManager : GLib.Object {
 		this.engines = new HashTable<string,weak IBus.EngineDesc>(str_hash, str_equal);
 	}
 
-	private void on_engines_get(GLib.Object? o, GLib.AsyncResult? res) {
+	private void on_engines_get(Object? o, AsyncResult? res) {
 		try {
 			this.enginelist = this.bus.list_engines_async_finish(res);
 			this.reset_ibus();
@@ -83,7 +83,7 @@ class AppletIBusManager : GLib.Object {
 				this.engines[engine.get_name()] = engine;
 			}
 		} catch (Error e) {
-			GLib.message("Failed to get engines: %s", e.message);
+			message("Failed to get engines: %s", e.message);
 			this.reset_ibus();
 			return;
 		}
@@ -243,7 +243,7 @@ public class KeyboardLayoutApplet : Budgie.Applet {
 		widget = new Gtk.EventBox();
 
 		/* Hook up the popover clicks */
-		widget.button_press_event.connect((e)=> {
+		widget.button_press_event.connect((e) => {
 			if (e.button != 1) {
 				return Gdk.EVENT_PROPAGATE;
 			}
@@ -445,7 +445,7 @@ public class KeyboardLayoutApplet : Budgie.Applet {
 			Gnome.get_input_source_from_locale(DEFAULT_LOCALE, out type, out id);
 		}
 
-		if(xkb.get_layout_info(id, out display_name, out short_name, out xkb_layout, out xkb_variant)) {
+		if (xkb.get_layout_info(id, out display_name, out short_name, out xkb_layout, out xkb_variant)) {
 			fallback = new InputSource(this.ibus_manager, id, 0, xkb_layout, xkb_variant, display_name, true);
 		} else {
 			fallback = new InputSource(this.ibus_manager, id, 0, DEFAULT_LAYOUT, DEFAULT_VARIANT, null, true);

--- a/src/applets/lock-keys/LockKeysApplet.vala
+++ b/src/applets/lock-keys/LockKeysApplet.vala
@@ -1,8 +1,8 @@
 /*
  * This file is part of budgie-desktop
- * 
+ *
  * Copyright © 2015-2019 Budgie Desktop Developers
- * 
+ *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or

--- a/src/applets/night-light/IndicatorWindow.vala
+++ b/src/applets/night-light/IndicatorWindow.vala
@@ -10,7 +10,7 @@
  */
 
 namespace NightLight {
-	[GtkTemplate (ui = "/org/budgie-desktop/night-light/indicator_window.ui")]
+	[GtkTemplate (ui="/org/budgie-desktop/night-light/indicator_window.ui")]
 	class IndicatorWindow : Budgie.Popover {
 		[GtkChild]
 		private Gtk.Switch? nightlight_switch;
@@ -24,16 +24,16 @@ namespace NightLight {
 		[GtkChild]
 		private Gtk.ComboBoxText? schedule_combobox;
 
-		private GLib.Settings settings;
+		private Settings settings;
 
 		public IndicatorWindow(Gtk.Widget? window_parent) {
 			Object(relative_to: window_parent);
 
-			settings = new GLib.Settings("org.gnome.settings-daemon.plugins.color");
+			settings = new Settings("org.gnome.settings-daemon.plugins.color");
 
-			settings.bind("night-light-enabled", nightlight_switch, "active", GLib.SettingsBindFlags.DEFAULT);
-			settings.bind("night-light-enabled", item_grid, "sensitive", GLib.SettingsBindFlags.DEFAULT);
-			settings.bind("night-light-temperature", temperature_spinbutton, "value", GLib.SettingsBindFlags.DEFAULT);
+			settings.bind("night-light-enabled", nightlight_switch, "active", SettingsBindFlags.DEFAULT);
+			settings.bind("night-light-enabled", item_grid, "sensitive", SettingsBindFlags.DEFAULT);
+			settings.bind("night-light-temperature", temperature_spinbutton, "value", SettingsBindFlags.DEFAULT);
 
 			settings.changed["night-light-schedule-automatic"].connect(() => {
 				schedule_combobox.set_active_id(settings.get_boolean("night-light-schedule-automatic").to_string());
@@ -54,7 +54,7 @@ namespace NightLight {
 
 		[GtkCallback]
 		private void open_settings() {
-			GLib.DesktopAppInfo app_info = new GLib.DesktopAppInfo("gnome-display-panel.desktop");
+			DesktopAppInfo app_info = new DesktopAppInfo("gnome-display-panel.desktop");
 
 			if (app_info == null) {
 				return;
@@ -63,7 +63,7 @@ namespace NightLight {
 			try {
 				this.hide();
 				app_info.launch(null, null);
-			} catch (GLib.Error e) {
+			} catch (Error e) {
 				message("Unable to launch gnome-display-panel.desktop: %s", e.message);
 			}
 		}

--- a/src/applets/night-light/NightLight.vala
+++ b/src/applets/night-light/NightLight.vala
@@ -34,7 +34,7 @@ namespace NightLight {
 			this.add(event_box);
 			this.show_all();
 
-			event_box.button_press_event.connect((e)=> {
+			event_box.button_press_event.connect((e) => {
 				if (e.button == 1) {
 					if (popover.get_visible()) {
 						popover.hide();

--- a/src/applets/notifications/NotificationsApplet.vala
+++ b/src/applets/notifications/NotificationsApplet.vala
@@ -1,8 +1,8 @@
 /*
  * This file is part of budgie-desktop
- * 
+ *
  * Copyright © 2015-2019 Budgie Desktop Developers
- * 
+ *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
@@ -17,11 +17,11 @@ public class NotificationsPlugin : Budgie.Plugin, Peas.ExtensionBase {
 
 private const string ALERT_SYMBOLIC = "notification-alert-symbolic";
 private const string DND_SYMBOLIC = "notification-disabled-symbolic";
-public const string RAVEN_DBUS_NAME		   = "org.budgie_desktop.Raven";
+public const string RAVEN_DBUS_NAME = "org.budgie_desktop.Raven";
 public const string RAVEN_DBUS_OBJECT_PATH = "/org/budgie_desktop/Raven";
 
 [DBus (name="org.budgie_desktop.Raven")]
-public interface RavenRemote : Object {
+public interface RavenRemote : GLib.Object {
 	public signal void DoNotDisturbChanged(bool active);
 	public abstract async bool GetDoNotDisturbState() throws Error;
 	public abstract async void ToggleNotificationsView() throws Error;
@@ -66,7 +66,7 @@ public class NotificationsApplet : Budgie.Applet {
 	}
 
 	/* Hold onto our Raven proxy ref */
-	void on_raven_get(GLib.Object? o, GLib.AsyncResult? res) {
+	void on_raven_get(Object? o, AsyncResult? res) {
 		try {
 			raven_proxy = Bus.get_proxy.end(res);
 			raven_proxy.DoNotDisturbChanged.connect(on_dnd_changed);
@@ -92,7 +92,7 @@ public class NotificationsApplet : Budgie.Applet {
 		this.icon.get_style_context().add_class("alert");
 	}
 
-	void on_get_count(GLib.Object? o, AsyncResult? res) {
+	void on_get_count(Object? o, AsyncResult? res) {
 		uint count = 0;
 
 		try {
@@ -111,7 +111,7 @@ public class NotificationsApplet : Budgie.Applet {
 		}
 	}
 
-	void on_get_dnd_state(GLib.Object? o, AsyncResult? res) {
+	void on_get_dnd_state(Object? o, AsyncResult? res) {
 		bool active = true; // Default to true
 
 		try {
@@ -144,7 +144,7 @@ public class NotificationsApplet : Budgie.Applet {
 		if (raven_proxy == null) {
 			return Gdk.EVENT_PROPAGATE;
 		}
-	
+
 		if (button.button != 1) {
 			return Gdk.EVENT_PROPAGATE;
 		}

--- a/src/applets/places-indicator/ListItem.vala
+++ b/src/applets/places-indicator/ListItem.vala
@@ -64,7 +64,7 @@ public abstract class ListItem : Gtk.Box {
 	 * Retrieves the file icon.
 	 * Returns an appropriate substitute if the file does not provide an icon
 	 */
-	protected Gtk.Image get_icon(GLib.Icon? icon) {
+	protected Gtk.Image get_icon(Icon? icon) {
 		if (icon != null) {
 			return new Gtk.Image.from_gicon(icon, Gtk.IconSize.MENU);
 		}
@@ -97,19 +97,19 @@ public abstract class ListItem : Gtk.Box {
 	/*
 	 * Opens the given directory
 	 */
-	protected void open_directory(GLib.File? root) {
+	protected void open_directory(File? root) {
 		if (root == null) {
 			return;
 		}
 
-		GLib.AppLaunchContext launch_context = Gdk.Display.get_default().get_app_launch_context();
-		GLib.List<GLib.File> file_list = new GLib.List<GLib.File>();
+		AppLaunchContext launch_context = Gdk.Display.get_default().get_app_launch_context();
+		List<File> file_list = new List<File>();
 		file_list.append(root);
 
 		try {
-			GLib.AppInfo.get_default_for_type("inode/directory", true).launch(file_list, launch_context);
+			AppInfo.get_default_for_type("inode/directory", true).launch(file_list, launch_context);
 			close_popover();
-		} catch (GLib.Error e) {
+		} catch (Error e) {
 			warning(e.message);
 		}
 	}

--- a/src/applets/places-indicator/MessageRevealer.vala
+++ b/src/applets/places-indicator/MessageRevealer.vala
@@ -37,7 +37,7 @@ public class MessageRevealer : Gtk.Revealer {
 
 	public bool hide_it() {
 		if (expire_id != 0) {
-			GLib.Source.remove(expire_id);
+			Source.remove(expire_id);
 		}
 
 		expire_id = 0;
@@ -46,7 +46,7 @@ public class MessageRevealer : Gtk.Revealer {
 			hide();
 		});
 		set_reveal_child(false);
-		GLib.Timeout.add(300, ()=> {
+		Timeout.add(300, () => {
 			this.disconnect(connection);
 			return false;
 		});
@@ -58,8 +58,8 @@ public class MessageRevealer : Gtk.Revealer {
 		show_it();
 
 		if (expire_id != 0) {
-			GLib.Source.remove(expire_id);
+			Source.remove(expire_id);
 		}
-		expire_id = GLib.Timeout.add(5000, hide_it);
+		expire_id = Timeout.add(5000, hide_it);
 	}
 }

--- a/src/applets/places-indicator/MountHelper.vala
+++ b/src/applets/places-indicator/MountHelper.vala
@@ -9,7 +9,7 @@
  * (at your option) any later version.
  */
 
-public class MountHelper : GLib.MountOperation {
+public class MountHelper : MountOperation {
 	private Gtk.Revealer revealer;
 	private Gtk.Entry password_entry;
 	private Gtk.Button unlock_button;
@@ -19,26 +19,26 @@ public class MountHelper : GLib.MountOperation {
 	public signal void request_mount();
 
 	public MountHelper() {
-		this.set_password_save(GLib.PasswordSave.FOR_SESSION);
+		this.set_password_save(PasswordSave.FOR_SESSION);
 
 		this.ask_password.connect(handle_password);
 		this.show_processes.connect(handle_block);
 		this.aborted.connect(handle_aborted);
 	}
 
-	private void handle_password(string message, string default_user, string default_domain, GLib.AskPasswordFlags flags) {
+	private void handle_password(string message, string default_user, string default_domain, AskPasswordFlags flags) {
 		password_asked();
-		this.reply(GLib.MountOperationResult.HANDLED);
+		this.reply(MountOperationResult.HANDLED);
 	}
 
 	private void handle_block() {
 		send_message(_("Volume is in use by other processes"));
-		this.reply(GLib.MountOperationResult.HANDLED);
+		this.reply(MountOperationResult.HANDLED);
 	}
 
 	private void handle_aborted() {
 		send_message(_("Operation aborted"));
-		this.reply(GLib.MountOperationResult.HANDLED);
+		this.reply(MountOperationResult.HANDLED);
 	}
 
 	public Gtk.Revealer get_encryption_form() {

--- a/src/applets/places-indicator/MountItem.vala
+++ b/src/applets/places-indicator/MountItem.vala
@@ -11,9 +11,9 @@
 
 public class MountItem : ListItem {
 	private MountHelper operation;
-	private GLib.Mount mount;
+	private Mount mount;
 
-	public MountItem(GLib.Mount mount, string? class) {
+	public MountItem(Mount mount, string? class) {
 		item_class = class;
 		this.mount = mount;
 
@@ -46,7 +46,7 @@ public class MountItem : ListItem {
 		unmount_button.set_halign(Gtk.Align.END);
 		overlay.add_overlay(unmount_button);
 
-		unmount_button.clicked.connect(()=> {
+		unmount_button.clicked.connect(() => {
 			if (mount.can_eject()) {
 				do_eject();
 			} else {
@@ -62,7 +62,7 @@ public class MountItem : ListItem {
 
 		name_button.set_tooltip_text(_("Open \"%s\"").printf(mount.get_name()));
 
-		name_button.clicked.connect(()=> {
+		name_button.clicked.connect(() => {
 			open_directory(mount.get_root());
 		});
 	}
@@ -71,16 +71,16 @@ public class MountItem : ListItem {
 	 * Ejects a mount
 	 */
 	private void do_eject() {
-		mount.eject_with_operation.begin(GLib.MountUnmountFlags.NONE, operation, null, on_eject);
+		mount.eject_with_operation.begin(MountUnmountFlags.NONE, operation, null, on_eject);
 		string safe_remove = _("You can now safely remove");
 		string device_name = mount.get_drive().get_name() ?? _("Unknown Device");
 		send_message(@"$safe_remove \"$device_name\"");
 	}
 
-	private void on_eject(GLib.Object? obj, GLib.AsyncResult res) {
+	private void on_eject(Object? obj, AsyncResult res) {
 		try {
 			mount.eject_with_operation.end(res);
-		} catch (GLib.Error e) {
+		} catch (Error e) {
 			send_message(_("Error while ejecting device"));
 			warning(e.message);
 		}
@@ -90,13 +90,13 @@ public class MountItem : ListItem {
 	 * Unmounts a mount
 	 */
 	private void do_unmount() {
-		mount.unmount_with_operation.begin(GLib.MountUnmountFlags.NONE, operation, null, on_unmount);
+		mount.unmount_with_operation.begin(MountUnmountFlags.NONE, operation, null, on_unmount);
 	}
 
-	private void on_unmount(GLib.Object? obj, GLib.AsyncResult res) {
+	private void on_unmount(Object? obj, AsyncResult res) {
 		try {
 			mount.unmount_with_operation.end(res);
-		} catch (GLib.Error e) {
+		} catch (Error e) {
 			send_message(_("Error while unmounting volume"));
 			warning(e.message);
 		}

--- a/src/applets/places-indicator/PlaceItem.vala
+++ b/src/applets/places-indicator/PlaceItem.vala
@@ -10,7 +10,7 @@
  */
 
 public class PlaceItem : ListItem {
-	public PlaceItem(GLib.File file, string class, string? bookmark_name) {
+	public PlaceItem(File file, string class, string? bookmark_name) {
 		item_class = class;
 
 		string name = "";
@@ -27,15 +27,15 @@ public class PlaceItem : ListItem {
 
 		// Get and set the appropriate icon
 		try {
-			GLib.FileInfo info = file.query_info("standard::symbolic-icon", GLib.FileQueryInfoFlags.NONE, null);
+			FileInfo info = file.query_info("standard::symbolic-icon", FileQueryInfoFlags.NONE, null);
 			set_button(name.strip(), get_icon(info.get_symbolic_icon()));
-		} catch (GLib.Error e) {
+		} catch (Error e) {
 			set_button(name.strip(), get_icon(null));
 		}
 
 		name_button.set_tooltip_text(_("Open \"%s\"".printf(name.strip())));
 
-		name_button.clicked.connect(()=> {
+		name_button.clicked.connect(() => {
 			open_directory(file);
 		});
 	}

--- a/src/applets/places-indicator/PlacesIndicator.vala
+++ b/src/applets/places-indicator/PlacesIndicator.vala
@@ -15,7 +15,7 @@ public class PlacesIndicator : Budgie.Plugin, Peas.ExtensionBase {
 	}
 }
 
-[GtkTemplate (ui = "/com/solus-project/places-indicator/settings.ui")]
+[GtkTemplate (ui="/com/solus-project/places-indicator/settings.ui")]
 public class PlacesIndicatorSettings : Gtk.Grid {
 	[GtkChild]
 	private Gtk.Switch? switch_label;
@@ -32,15 +32,15 @@ public class PlacesIndicatorSettings : Gtk.Grid {
 	[GtkChild]
 	private Gtk.Switch? switch_networks;
 
-	private GLib.Settings? settings;
+	private Settings? settings;
 
-	public PlacesIndicatorSettings(GLib.Settings? settings) {
+	public PlacesIndicatorSettings(Settings? settings) {
 		this.settings = settings;
-		settings.bind("show-label", switch_label, "active", GLib.SettingsBindFlags.DEFAULT);
-		settings.bind("expand-places", switch_expand_places, "active", GLib.SettingsBindFlags.DEFAULT);
-		settings.bind("show-places", switch_places, "active", GLib.SettingsBindFlags.DEFAULT);
-		settings.bind("show-drives", switch_drives, "active", GLib.SettingsBindFlags.DEFAULT);
-		settings.bind("show-networks", switch_networks, "active", GLib.SettingsBindFlags.DEFAULT);
+		settings.bind("show-label", switch_label, "active", SettingsBindFlags.DEFAULT);
+		settings.bind("expand-places", switch_expand_places, "active", SettingsBindFlags.DEFAULT);
+		settings.bind("show-places", switch_places, "active", SettingsBindFlags.DEFAULT);
+		settings.bind("show-drives", switch_drives, "active", SettingsBindFlags.DEFAULT);
+		settings.bind("show-networks", switch_networks, "active", SettingsBindFlags.DEFAULT);
 	}
 }
 
@@ -52,7 +52,7 @@ public class PlacesIndicatorApplet : Budgie.Applet {
 	private Budgie.PanelPosition panel_position = Budgie.PanelPosition.BOTTOM;
 
 	private unowned Budgie.PopoverManager? manager = null;
-	private GLib.Settings settings;
+	private Settings settings;
 	public string uuid { public set ; public get; }
 
 	public override Gtk.Widget? get_settings_ui() {
@@ -83,7 +83,7 @@ public class PlacesIndicatorApplet : Budgie.Applet {
 
 		popover = new PlacesIndicatorWindow(image);
 
-		ebox.button_press_event.connect((e)=> {
+		ebox.button_press_event.connect((e) => {
 			if (e.button != 1) {
 				return Gdk.EVENT_PROPAGATE;
 			}

--- a/src/applets/places-indicator/PlacesIndicatorWindow.vala
+++ b/src/applets/places-indicator/PlacesIndicatorWindow.vala
@@ -10,7 +10,7 @@
  */
 
 public class PlacesIndicatorWindow : Budgie.Popover {
-	private GLib.VolumeMonitor volume_monitor;
+	private VolumeMonitor volume_monitor;
 
 	private MessageRevealer message_bar;
 	private PlacesSection places_section;
@@ -19,7 +19,7 @@ public class PlacesIndicatorWindow : Budgie.Popover {
 	private Gtk.ListBox networks_listbox;
 	private Gtk.Box placeholder;
 
-	private GLib.GenericSet<string> places_list;
+	private GenericSet<string> places_list;
 
 	private bool _expand_places = false;
 	private bool _show_places = false;
@@ -28,7 +28,7 @@ public class PlacesIndicatorWindow : Budgie.Popover {
 
 	private bool only_places = true;
 
-	private GLib.FileMonitor bookmarks_monitor;
+	private FileMonitor bookmarks_monitor;
 
 	public bool expand_places {
 		get { return _expand_places; }
@@ -63,12 +63,12 @@ public class PlacesIndicatorWindow : Budgie.Popover {
 		}
 	}
 
-	private GLib.UserDirectory[] DEFAULT_DIRECTORIES = {
-		GLib.UserDirectory.DOCUMENTS,
-		GLib.UserDirectory.DOWNLOAD,
-		GLib.UserDirectory.MUSIC,
-		GLib.UserDirectory.PICTURES,
-		GLib.UserDirectory.VIDEOS
+	private UserDirectory[] DEFAULT_DIRECTORIES = {
+		UserDirectory.DOCUMENTS,
+		UserDirectory.DOWNLOAD,
+		UserDirectory.MUSIC,
+		UserDirectory.PICTURES,
+		UserDirectory.VIDEOS
 	};
 
 	public PlacesIndicatorWindow(Gtk.Widget? window_parent) {
@@ -76,7 +76,7 @@ public class PlacesIndicatorWindow : Budgie.Popover {
 		set_size_request(280, 0);
 		get_style_context().add_class("places-menu");
 
-		places_list = new GLib.GenericSet<string>(str_hash, str_equal);
+		places_list = new GenericSet<string>(str_hash, str_equal);
 
 		Gtk.Box main_content = new Gtk.Box(Gtk.Orientation.VERTICAL, 0);
 		main_content.get_style_context().add_class("container");
@@ -103,7 +103,7 @@ public class PlacesIndicatorWindow : Budgie.Popover {
 		main_content.pack_start(placeholder, true, true, 0);
 		placeholder.hide();
 
-		volume_monitor = GLib.VolumeMonitor.get();
+		volume_monitor = VolumeMonitor.get();
 
 		connect_signals();
 
@@ -150,7 +150,7 @@ public class PlacesIndicatorWindow : Budgie.Popover {
 		}
 
 		if (before == null || after == null || prev != next) {
-			Gtk.Label label = new Gtk.Label(GLib.Markup.printf_escaped("<span font=\"11\">%s</span>", prev));
+			Gtk.Label label = new Gtk.Label(Markup.printf_escaped("<span font=\"11\">%s</span>", prev));
 			label.get_style_context().add_class("dim-label");
 			label.set_halign(Gtk.Align.START);
 			label.set_use_markup(true);
@@ -192,35 +192,35 @@ public class PlacesIndicatorWindow : Budgie.Popover {
 	}
 
 	/*
-	 * Returns a GLib.File for the bookmarks file location
+	 * Returns a File for the bookmarks file location
 	 */
-	private GLib.File get_bookmarks_file() {
-		string path = GLib.Path.build_filename(GLib.Environment.get_user_config_dir(), "gtk-3.0", "bookmarks");
-		return GLib.File.new_for_path(path);
+	private File get_bookmarks_file() {
+		string path = Path.build_filename(Environment.get_user_config_dir(), "gtk-3.0", "bookmarks");
+		return File.new_for_path(path);
 	}
 
 	/*
 	 * Sets up a file monitor for the bookmarks file and listens for changes
 	 */
 	private void connect_bookmarks_monitor() {
-		GLib.File bookmarks_file = get_bookmarks_file();
+		File bookmarks_file = get_bookmarks_file();
 		if (!bookmarks_file.query_exists()) {
 			return;
 		}
 
 		try {
-			bookmarks_monitor = bookmarks_file.monitor_file(GLib.FileMonitorFlags.WATCH_MOVES, null);
+			bookmarks_monitor = bookmarks_file.monitor_file(FileMonitorFlags.WATCH_MOVES, null);
 			bookmarks_monitor.set_rate_limit(1000);
 
 			// Refresh special directories (including the bookmarks) when the file changes
 			bookmarks_monitor.changed.connect(on_bookmarks_change);
-		} catch (GLib.IOError e) {
+		} catch (IOError e) {
 			warning(e.message);
 		}
 	}
 
-	private void on_bookmarks_change(GLib.File src, GLib.File? dest, GLib.FileMonitorEvent event) {
-		if ((event == GLib.FileMonitorEvent.CHANGES_DONE_HINT) || (event == GLib.FileMonitorEvent.RENAMED)) {
+	private void on_bookmarks_change(File src, File? dest, FileMonitorEvent event) {
+		if ((event == FileMonitorEvent.CHANGES_DONE_HINT) || (event == FileMonitorEvent.RENAMED)) {
 			refresh_special_dirs();
 		}
 	}
@@ -301,17 +301,17 @@ public class PlacesIndicatorWindow : Budgie.Popover {
 	 * Reads the bookmarks file and adds all of the bookmarks to the view
 	 */
 	private void refresh_bookmarks() {
-		GLib.File bookmarks_file = get_bookmarks_file();
+		File bookmarks_file = get_bookmarks_file();
 		if (!bookmarks_file.query_exists()) {
 			return;
 		}
 		try {
-			var dis = new GLib.DataInputStream(bookmarks_file.read());
+			var dis = new DataInputStream(bookmarks_file.read());
 			string line;
 			while ((line = dis.read_line(null)) != null) {
 				add_place(line, "bookmark");
 			}
-		} catch (GLib.Error e) {
+		} catch (Error e) {
 			warning(e.message);
 		}
 	}
@@ -324,11 +324,11 @@ public class PlacesIndicatorWindow : Budgie.Popover {
 		places_section.clear();
 
 		// Add home dir
-		string path = GLib.Environment.get_home_dir();
+		string path = Environment.get_home_dir();
 		add_place(@"file://$path", "place");
 
 		foreach (var special_dir in DEFAULT_DIRECTORIES) {
-			path = GLib.Environment.get_user_special_dir(special_dir);
+			path = Environment.get_user_special_dir(special_dir);
 			add_place(@"file://$path", "place");
 		}
 
@@ -348,9 +348,9 @@ public class PlacesIndicatorWindow : Budgie.Popover {
 		}
 
 		// Add volumes connected with a drive
-		foreach (GLib.Drive drive in volume_monitor.get_connected_drives()) {
-			foreach (GLib.Volume volume in drive.get_volumes()) {
-				GLib.Mount mount = volume.get_mount();
+		foreach (Drive drive in volume_monitor.get_connected_drives()) {
+			foreach (Volume volume in drive.get_volumes()) {
+				Mount mount = volume.get_mount();
 				if (mount == null) {
 					add_volume(volume);
 				} else {
@@ -360,11 +360,11 @@ public class PlacesIndicatorWindow : Budgie.Popover {
 		}
 
 		// Add volumes not connected with a drive
-		foreach (GLib.Volume volume in volume_monitor.get_volumes()) {
+		foreach (Volume volume in volume_monitor.get_volumes()) {
 			if (volume.get_drive() != null) {
 				continue;
 			}
-			GLib.Mount mount = volume.get_mount();
+			Mount mount = volume.get_mount();
 			if (mount == null) {
 				add_volume(volume);
 			} else {
@@ -373,12 +373,12 @@ public class PlacesIndicatorWindow : Budgie.Popover {
 		}
 
 		// Add mounts without volumes
-		foreach (GLib.Mount mount in volume_monitor.get_mounts()) {
+		foreach (Mount mount in volume_monitor.get_mounts()) {
 			if (mount.is_shadowed() || mount.get_volume() != null) {
 				continue;
 			}
 
-			GLib.File root = mount.get_default_location();
+			File root = mount.get_default_location();
 
 			if (!root.is_native()) {
 				add_mount(mount, "network");
@@ -394,7 +394,7 @@ public class PlacesIndicatorWindow : Budgie.Popover {
 	/*
 	 * Adds a volume to the view
 	 */
-	private void add_volume(GLib.Volume volume) {
+	private void add_volume(Volume volume) {
 		string? volume_class = volume.get_identifier("class");
 
 		VolumeItem volume_item = new VolumeItem(volume);
@@ -414,7 +414,7 @@ public class PlacesIndicatorWindow : Budgie.Popover {
 	/*
 	 * Adds a mount to the view
 	 */
-	private void add_mount(GLib.Mount mount, string? mount_class) {
+	private void add_mount(Mount mount, string? mount_class) {
 		if (!mount.can_unmount() && !mount.can_eject()) {
 			return;
 		}
@@ -448,13 +448,13 @@ public class PlacesIndicatorWindow : Budgie.Popover {
 		for (int i = 1; i < arr.length; i++) {
 			place_name += arr[i] + " ";
 		}
-		string unescaped_path = GLib.Uri.unescape_string(place);
+		string unescaped_path = Uri.unescape_string(place);
 
 		if (places_list.contains(unescaped_path)) {
 			return;
 		}
 
-		GLib.File file = GLib.File.new_for_uri(unescaped_path);
+		File file = File.new_for_uri(unescaped_path);
 
 		PlaceItem place_item;
 		if (class == "bookmark" && place_name != "") {

--- a/src/applets/places-indicator/VolumeItem.vala
+++ b/src/applets/places-indicator/VolumeItem.vala
@@ -12,10 +12,10 @@
 public class VolumeItem : ListItem {
 	private MountHelper operation;
 	private Gtk.Revealer? unlock_revealer = null;
-	private GLib.Volume volume;
+	private Volume volume;
 	private bool first_try = true;
 
-	public VolumeItem(GLib.Volume volume) {
+	public VolumeItem(Volume volume) {
 		item_class = volume.get_identifier("class");
 		this.volume = volume;
 
@@ -42,7 +42,7 @@ public class VolumeItem : ListItem {
 
 		operation = new MountHelper();
 
-		operation.send_message.connect((message)=> { send_message(message); });
+		operation.send_message.connect((message) => { send_message(message); });
 		operation.password_asked.connect(on_password_asked);
 		operation.request_mount.connect(do_mount);
 
@@ -62,7 +62,7 @@ public class VolumeItem : ListItem {
 	}
 
 	private void on_eject_button_clicked() {
-		volume.eject_with_operation.begin(GLib.MountUnmountFlags.NONE, operation, null, on_eject);
+		volume.eject_with_operation.begin(MountUnmountFlags.NONE, operation, null, on_eject);
 	}
 
 	private void on_name_button_clicked() {
@@ -77,13 +77,13 @@ public class VolumeItem : ListItem {
 		}
 	}
 
-	private void on_eject(GLib.Object? obj, GLib.AsyncResult res) {
+	private void on_eject(Object? obj, AsyncResult res) {
 		try {
 			volume.eject_with_operation.end(res);
 			string safe_remove = _("You can now safely remove");
 			string device_name = volume.get_drive().get_name();
 			send_message(@"$safe_remove \"$device_name\"");
-		} catch (GLib.Error e) {
+		} catch (Error e) {
 			send_message(e.message);
 			warning(e.message);
 		}
@@ -100,14 +100,14 @@ public class VolumeItem : ListItem {
 
 	private void do_mount() {
 		spin.start();
-		volume.mount.begin(GLib.MountMountFlags.NONE, operation, null, on_mount);
+		volume.mount.begin(MountMountFlags.NONE, operation, null, on_mount);
 	}
 
-	private void on_mount(GLib.Object? obj, GLib.AsyncResult res) {
+	private void on_mount(Object? obj, AsyncResult res) {
 		try {
 			volume.mount.end(res);
 			open_directory(volume.get_mount().get_root());
-		} catch (GLib.Error e) {
+		} catch (Error e) {
 			if ("No key available with this passphrase" in e.message) {
 				send_message(_("The password you entered is incorrect"));
 			} else if (first_try && unlock_revealer != null) {

--- a/src/applets/raven-trigger/RavenTriggerApplet.vala
+++ b/src/applets/raven-trigger/RavenTriggerApplet.vala
@@ -1,19 +1,19 @@
 /*
  * This file is part of budgie-desktop
- * 
+ *
  * Copyright © 2015-2019 Budgie Desktop Developers
- * 
+ *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
  * (at your option) any later version.
  */
 
-public const string RAVEN_DBUS_NAME		   = "org.budgie_desktop.Raven";
+public const string RAVEN_DBUS_NAME = "org.budgie_desktop.Raven";
 public const string RAVEN_DBUS_OBJECT_PATH = "/org/budgie_desktop/Raven";
 
 [DBus (name="org.budgie_desktop.Raven")]
-public interface RavenTriggerProxy : Object {
+public interface RavenTriggerProxy : GLib.Object {
 	public abstract async void ToggleAppletView() throws Error;
 	public abstract bool GetExpanded() throws Error;
 	public abstract bool GetLeftAnchored() throws Error;
@@ -129,17 +129,17 @@ public class RavenTriggerApplet : Budgie.Applet {
 	}
 
 	/* Hold onto our Raven proxy ref */
-	void on_raven_get(GLib.Object? o, GLib.AsyncResult? res) {
+	void on_raven_get(Object? o, AsyncResult? res) {
 		try {
 			raven_proxy = Bus.get_proxy.end(res);
-			raven_proxy.ExpansionChanged.connect_after((e)=> {
-				Idle.add(()=> {
+			raven_proxy.ExpansionChanged.connect_after((e) => {
+				Idle.add(() => {
 					on_prop_changed(e);
 					return false;
 				});
 			});
-			raven_proxy.AnchorChanged.connect((e)=> {
-				Idle.add(()=> {
+			raven_proxy.AnchorChanged.connect((e) => {
+				Idle.add(() => {
 					on_anchor_changed(e);
 					return false;
 				});

--- a/src/applets/separator/SeparatorApplet.vala
+++ b/src/applets/separator/SeparatorApplet.vala
@@ -1,8 +1,8 @@
 /*
  * This file is part of budgie-desktop
- * 
+ *
  * Copyright © 2015-2019 Budgie Desktop Developers
- * 
+ *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or

--- a/src/applets/show-desktop/ShowDesktopApplet.vala
+++ b/src/applets/show-desktop/ShowDesktopApplet.vala
@@ -1,8 +1,8 @@
 /*
  * This file is part of budgie-desktop
- * 
+ *
  * Copyright © 2015-2019 Budgie Desktop Developers
- * 
+ *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or

--- a/src/applets/spacer/SpacerApplet.vala
+++ b/src/applets/spacer/SpacerApplet.vala
@@ -15,7 +15,7 @@ public class SpacerPlugin : Budgie.Plugin, Peas.ExtensionBase {
 	}
 }
 
-[GtkTemplate (ui = "/com/solus-project/spacer/settings.ui")]
+[GtkTemplate (ui="/com/solus-project/spacer/settings.ui")]
 public class SpacerSettings : Gtk.Grid {
 	Settings? settings = null;
 

--- a/src/applets/status/BluetoothIndicator.vala
+++ b/src/applets/status/BluetoothIndicator.vala
@@ -13,7 +13,7 @@
  */
 
 [DBus (name="org.gnome.SettingsDaemon.Rfkill")]
-public interface Rfkill : Object {
+public interface Rfkill : GLib.Object {
 	public abstract bool BluetoothAirplaneMode { set; get; }
 }
 
@@ -83,7 +83,7 @@ public class BluetoothIndicator : Gtk.Bin {
 
 		this.resync();
 
-		this.setup_dbus.begin(()=> {
+		this.setup_dbus.begin(() => {
 			if (this.killer == null) {
 				return;
 			}

--- a/src/applets/status/SoundIndicator.vala
+++ b/src/applets/status/SoundIndicator.vala
@@ -1,8 +1,8 @@
 /*
  * This file is part of budgie-desktop
- * 
+ *
  * Copyright © 2015-2019 Budgie Desktop Developers
- * 
+ *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
@@ -104,7 +104,7 @@ public class SoundIndicator : Gtk.Bin {
 
 		/* - button */
 		popover_box.pack_start(sub_button, false, false, 1);
-		sub_button.clicked.connect(()=> {
+		sub_button.clicked.connect(() => {
 			adjust_volume_increment(-step_size);
 		});
 
@@ -116,7 +116,7 @@ public class SoundIndicator : Gtk.Bin {
 
 		/* + button */
 		popover_box.pack_start(plus_button, false, false, 1);
-		plus_button.clicked.connect(()=> {
+		plus_button.clicked.connect(() => {
 			adjust_volume_increment(+step_size);
 		});
 

--- a/src/applets/status/StatusApplet.vala
+++ b/src/applets/status/StatusApplet.vala
@@ -26,7 +26,7 @@ public class StatusApplet : Budgie.Applet {
 	 * Set up an EventBox for popovers
 	 */
 	private void setup_popover(Gtk.Widget? parent_widget, Budgie.Popover? popover) {
-		parent_widget.button_press_event.connect((e)=> {
+		parent_widget.button_press_event.connect((e) => {
 			if (e.button != 1) {
 				return Gdk.EVENT_PROPAGATE;
 			}

--- a/src/applets/tasklist/TasklistApplet.vala
+++ b/src/applets/tasklist/TasklistApplet.vala
@@ -1,8 +1,8 @@
 /*
  * This file is part of budgie-desktop
- * 
+ *
  * Copyright © 2015-2019 Budgie Desktop Developers
- * 
+ *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or

--- a/src/applets/tray/TrayApplet.vala
+++ b/src/applets/tray/TrayApplet.vala
@@ -15,7 +15,7 @@ public class TrayPlugin : Budgie.Plugin, Peas.ExtensionBase {
 	}
 }
 
-[GtkTemplate (ui = "/com/solus-project/tray/settings.ui")]
+[GtkTemplate (ui="/com/solus-project/tray/settings.ui")]
 public class TraySettings : Gtk.Grid {
 	Settings? settings = null;
 

--- a/src/applets/tray/carbontray/carbontray-1.0.vapi
+++ b/src/applets/tray/carbontray/carbontray-1.0.vapi
@@ -1,14 +1,14 @@
 namespace Carbon {
     [Compact]
-    [CCode (cheader_filename = "tray.h")]
+    [CCode (cheader_filename="tray.h")]
 	public class Tray : GLib.Object {
-        [CCode (has_construct_function = false, type = "GtkWidget*")]
+        [CCode (has_construct_function=false, type = "GtkWidget*")]
         public Tray(Gtk.Orientation orientation, int iconSize, int spacing);
 
         public void add_to_container(Gtk.Container container);
 
         public void remove_from_container(Gtk.Container container);
-        
+
         public bool register(Gdk.X11.Screen screen);
 
         public void unregister();

--- a/src/applets/user-indicator/DBusInterfaces.vala
+++ b/src/applets/user-indicator/DBusInterfaces.vala
@@ -9,37 +9,37 @@
  * (at your option) any later version.
  */
 
-[DBus (name = "org.freedesktop.Accounts")]
-interface AccountsInterface : Object {
+[DBus (name="org.freedesktop.Accounts")]
+interface AccountsInterface : GLib.Object {
 	public abstract string find_user_by_name(string username) throws IOError;
 }
 
-[DBus (name = "org.freedesktop.Accounts.User")]
-interface AccountUserInterface : Object {
+[DBus (name="org.freedesktop.Accounts.User")]
+interface AccountUserInterface : GLib.Object {
 	public signal void changed();
 }
 
-[DBus (name = "org.freedesktop.DBus.Properties")]
-interface PropertiesInterface : Object {
+[DBus (name="org.freedesktop.DBus.Properties")]
+interface PropertiesInterface : GLib.Object {
 	public abstract Variant get(string interface, string property) throws IOError;
 	public signal void properties_changed();
 }
 
 /* logind */
-[DBus (name = "org.freedesktop.login1.Manager")]
-public interface LogindInterface : Object {
+[DBus (name="org.freedesktop.login1.Manager")]
+public interface LogindInterface : GLib.Object {
 	public abstract void suspend(bool interactive) throws IOError;
 	public abstract void hibernate(bool interactive) throws IOError;
 }
 
 [DBus (name="org.gnome.SessionManager")]
-public interface SessionManager : Object {
-	public abstract void Logout (uint mode) throws IOError;
+public interface SessionManager : GLib.Object {
+	public abstract void Logout(uint mode) throws IOError;
 	public abstract async void Reboot() throws Error;
 	public abstract async void Shutdown() throws Error;
 }
 
 [DBus (name="org.gnome.ScreenSaver")]
-public interface ScreenSaver : Object {
+public interface ScreenSaver : GLib.Object {
 	public abstract void lock() throws Error;
 }

--- a/src/applets/user-indicator/UserIndicator.vala
+++ b/src/applets/user-indicator/UserIndicator.vala
@@ -1,6 +1,6 @@
 /*
  * This file is part of budgie-desktop
- * 
+ *
  * Copyright © 2015-2019 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
@@ -27,14 +27,14 @@ public class UserIndicatorApplet : Budgie.Applet {
 
 	public UserIndicatorApplet(string uuid) {
 		Object(uuid: uuid);
-		
+
 		ebox = new Gtk.EventBox();
 		image = new Gtk.Image.from_icon_name(USER_SYMBOLIC_ICON, Gtk.IconSize.MENU);
-		ebox.add(image); 
+		ebox.add(image);
 
 		popover = new UserIndicatorWindow(image);
 
-		ebox.button_press_event.connect((e)=> {
+		ebox.button_press_event.connect((e) => {
 			if (e.button != 1) {
 				return Gdk.EVENT_PROPAGATE;
 			}
@@ -47,24 +47,24 @@ public class UserIndicatorApplet : Budgie.Applet {
 		add(ebox);
 		show_all();
 	}
-	
+
 	public void Toggle(){
 		if (popover.get_visible()) {
 			popover.hide();
 		} else {
 			popover.get_child().show_all();
 			this.manager.show_popover(ebox);
-		}		 
+		}
 	}
-	
+
 	public override void invoke_action(Budgie.PanelAction action) {
 		Toggle();
 	}
-	
+
 	public override void update_popovers(Budgie.PopoverManager? manager) {
 		this.manager = manager;
 		manager.register_popover(ebox, popover);
-	}	 
+	}
 }
 
 [ModuleInit]

--- a/src/applets/user-indicator/UserIndicatorWindow.vala
+++ b/src/applets/user-indicator/UserIndicatorWindow.vala
@@ -78,7 +78,7 @@ public class UserIndicatorWindow : Budgie.Popover {
 
 	public UserIndicatorWindow(Gtk.Widget? window_parent) {
 		Object(relative_to: window_parent);
-		current_username = GLib.Environment.get_user_name();
+		current_username = Environment.get_user_name();
 
 		setup_dbus.begin();
 
@@ -265,7 +265,7 @@ public class UserIndicatorWindow : Budgie.Popover {
 			return;
 		}
 
-		Idle.add(()=> {
+		Idle.add(() => {
 			try {
 				session.Logout(0);
 			} catch (Error e) {
@@ -281,7 +281,7 @@ public class UserIndicatorWindow : Budgie.Popover {
 			return;
 		}
 
-		Idle.add(()=> {
+		Idle.add(() => {
 			try {
 				lock_screen();
 				logind_interface.hibernate(false);
@@ -298,7 +298,7 @@ public class UserIndicatorWindow : Budgie.Popover {
 			return;
 		}
 
-		Idle.add(()=> {
+		Idle.add(() => {
 			session.Reboot.begin();
 			return false;
 		});
@@ -310,7 +310,7 @@ public class UserIndicatorWindow : Budgie.Popover {
 			return;
 		}
 
-		Idle.add(()=> {
+		Idle.add(() => {
 			session.Shutdown.begin();
 			return false;
 		});
@@ -322,7 +322,7 @@ public class UserIndicatorWindow : Budgie.Popover {
 			return;
 		}
 
-		Idle.add(()=> {
+		Idle.add(() => {
 			try {
 				lock_screen();
 				logind_interface.suspend(false);
@@ -335,7 +335,7 @@ public class UserIndicatorWindow : Budgie.Popover {
 
 	private void lock_screen() {
 		hide();
-		Idle.add(()=> {
+		Idle.add(() => {
 			try {
 				saver.lock();
 			} catch (Error e) {

--- a/src/applets/workspaces/WorkspaceItem.vala
+++ b/src/applets/workspaces/WorkspaceItem.vala
@@ -10,7 +10,7 @@
  */
 
 namespace Workspaces {
-	const Gtk.TargetEntry[] target_list = { 
+	const Gtk.TargetEntry[] target_list = {
 		{ "application/x-wnck-window-id", 0, 0 }
 	};
 
@@ -182,7 +182,7 @@ namespace Workspaces {
 			Gtk.drag_finish(context, dnd_success, true, time);
 		}
 
-		public void update_windows(GLib.List<unowned Wnck.Window> window_list) {
+		public void update_windows(List<unowned Wnck.Window> window_list) {
 			int column_offset = 0;
 			int row_offset = 0;
 

--- a/src/appsys/AppSystem.vala
+++ b/src/appsys/AppSystem.vala
@@ -16,12 +16,12 @@ namespace Budgie {
 		HashTable<string?,DesktopAppInfo?> desktops = null;
 		/* Mapping of based TryExec to desktop ID */
 		HashTable<string?,string?> exec_cache = null;
-		HashTable<int64?, string?> pid_cache = null;
+		HashTable<int64?,string?> pid_cache = null;
 		AppInfoMonitor? monitor = null;
 
 		bool invalidated = false;
 
-		private GLib.DBusConnection bus;
+		private DBusConnection bus;
 
 		public signal void app_launched(string desktop_file);
 
@@ -38,9 +38,9 @@ namespace Budgie {
 
 			pid_cache = new HashTable<int64?,string?>(str_hash, str_equal);
 
-			GLib.Bus.@get.begin(GLib.BusType.SESSION, null, (obj, res) => {
+			Bus.@get.begin(BusType.SESSION, null, (obj, res) => {
 				try {
-					bus = GLib.Bus.@get.end(res);
+					bus = Bus.@get.end(res);
 					bus.signal_subscribe(null,
 										"org.gtk.gio.DesktopAppInfo",
 										"Launched",
@@ -48,14 +48,14 @@ namespace Budgie {
 										null,
 										0,
 										this.signal_received);
-				} catch (GLib.IOError e) {
+				} catch (IOError e) {
 					warning(e.message);
 				}
 			});
 
 			monitor = AppInfoMonitor.get();
-			monitor.changed.connect(()=> {
-				Idle.add(()=> {
+			monitor.changed.connect(() => {
+				Idle.add(() => {
 					lock(invalidated) {
 						invalidated = true;
 					}
@@ -65,13 +65,13 @@ namespace Budgie {
 			reload_ids();
 		}
 
-		private void signal_received(GLib.DBusConnection connection,
+		private void signal_received(DBusConnection connection,
 									string? sender,
 									string object_path,
 									string interface_name,
 									string signal_name,
-									GLib.Variant parameters) {
-			GLib.Variant desktop_variant;
+									Variant parameters) {
+			Variant desktop_variant;
 			int64 pid;
 
 			parameters.get("(@aysxas@a{sv})", out desktop_variant, null, out pid, null, null);
@@ -172,7 +172,7 @@ namespace Budgie {
 			/* See if the pid associated with the window is in our pid cache */
 			if (pid in pid_cache) {
 				string filename = pid_cache[pid];
-				GLib.DesktopAppInfo? info = new GLib.DesktopAppInfo.from_filename(filename);
+				DesktopAppInfo? info = new DesktopAppInfo.from_filename(filename);
 				return info;
 			}
 

--- a/src/config/budgie-config.vapi
+++ b/src/config/budgie-config.vapi
@@ -1,6 +1,6 @@
 /*
  * This file is part of budgie-desktop
- * 
+ *
  * Copyright © 2015-2017 Budgie Desktop Developers
  *
  * This library is free software; you can redistribute it and/or
@@ -10,27 +10,27 @@
  */
 
 namespace Budgie {
-    [CCode (cheader_filename = "budgie-config.h")]
+    [CCode (cheader_filename="budgie-config.h")]
     public extern const string MODULE_DIRECTORY;
 
-    [CCode (cheader_filename = "budgie-config.h")]
+    [CCode (cheader_filename="budgie-config.h")]
     public extern const string MODULE_DATA_DIRECTORY;
 
-    [CCode (cheader_filename = "budgie-config.h")]
+    [CCode (cheader_filename="budgie-config.h")]
     public extern const string DATADIR;
 
-    [CCode (cheader_filename = "budgie-config.h")]
+    [CCode (cheader_filename="budgie-config.h")]
     public extern const string CONFDIR;
 
-    [CCode (cheader_filename = "budgie-config.h")]
+    [CCode (cheader_filename="budgie-config.h")]
     public extern const string VERSION;
 
-    [CCode (cheader_filename = "budgie-config.h")]
+    [CCode (cheader_filename="budgie-config.h")]
     public extern const string WEBSITE;
 
-    [CCode (cheader_filename = "budgie-config.h")]
+    [CCode (cheader_filename="budgie-config.h")]
     public extern const string GETTEXT_PACKAGE;
 
-    [CCode (cheader_filename = "budgie-config.h")]
+    [CCode (cheader_filename="budgie-config.h")]
     public extern const string LOCALEDIR;
 }

--- a/src/daemon/endsession.vala
+++ b/src/daemon/endsession.vala
@@ -1,8 +1,8 @@
 /*
  * This file is part of budgie-desktop
- * 
+ *
  * Copyright © 2015-2019 Budgie Desktop Developers
- * 
+ *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
@@ -11,7 +11,7 @@
 
 namespace Budgie {
 	/* Currently unused by us */
-	[DBus (name = "org.gnome.SessionManager.Inhibitor")]
+	[DBus (name="org.gnome.SessionManager.Inhibitor")]
 	public interface Inhibitor : GLib.Object {
 		public abstract string GetAppId() throws Error;
 		public abstract string GetReason() throws Error;
@@ -25,7 +25,7 @@ namespace Budgie {
 	}
 
 	[GtkTemplate (ui="/com/solus-project/budgie/endsession/endsession.ui")]
-	[DBus (name = "org.budgie_desktop.Session.EndSessionDialog")]
+	[DBus (name="org.budgie_desktop.Session.EndSessionDialog")]
 	public class EndSessionDialog : Gtk.Window {
 		public signal void ConfirmedLogout();
 		public signal void ConfirmedReboot();
@@ -78,7 +78,7 @@ namespace Budgie {
 			ConfirmedShutdown();
 		}
 
-		[DBus (visible = false)]
+		[DBus (visible=false)]
 		void on_bus_acquired(DBusConnection conn) {
 			try {
 				conn.register_object("/org/budgie_desktop/Session/EndSessionDialog", this);
@@ -91,7 +91,7 @@ namespace Budgie {
 		/**
 		* Attempt to set the RGBA visual
 		*/
-		[DBus (visible = false)]
+		[DBus (visible=false)]
 		private void on_realized() {
 			Gdk.Visual? visual = screen.get_rgba_visual();
 			if (visual != null) {
@@ -104,7 +104,7 @@ namespace Budgie {
 		* This is required as we may be constructed before the window manager
 		* springs into life
 		*/
-		[DBus (visible = false)]
+		[DBus (visible=false)]
 		private void on_composite_changed() {
 			Gdk.Visual? visual = screen.get_rgba_visual();
 			if (visual != null) {
@@ -114,14 +114,14 @@ namespace Budgie {
 			}
 		}
 
-		[DBus (visible = false)]
+		[DBus (visible=false)]
 		public EndSessionDialog(bool replace) {
 			var flags = BusNameOwnerFlags.ALLOW_REPLACEMENT;
 			if (replace) {
 				flags |= BusNameOwnerFlags.REPLACE;
 			}
 			Bus.own_name(BusType.SESSION, "org.budgie_desktop.Session.EndSessionDialog", flags,
-				on_bus_acquired, ()=> {} , Budgie.DaemonNameLost);
+				on_bus_acquired, () => {}, Budgie.DaemonNameLost);
 			set_keep_above(true);
 			set_resizable(false);
 
@@ -132,7 +132,7 @@ namespace Budgie {
 			set_titlebar(header);
 			header.get_style_context().remove_class("titlebar");
 
-			delete_event.connect(()=> {
+			delete_event.connect(() => {
 				this.cancel_clicked();
 				return Gdk.EVENT_STOP;
 			});

--- a/src/daemon/main.vala
+++ b/src/daemon/main.vala
@@ -1,8 +1,8 @@
 /*
  * This file is part of budgie-desktop
- * 
+ *
  * Copyright (C) 2016-2019 Budgie Desktop Developers
- * 
+ *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
@@ -14,7 +14,9 @@
  */
 static bool replace = false;
 
-const GLib.OptionEntry[] options = { { "replace", 0, 0, OptionArg.NONE, ref replace, "Replace currently running daemon" }, { null }
+const OptionEntry[] options = {
+	{ "replace", 0, 0, OptionArg.NONE, ref replace, "Replace currently running daemon" },
+	{ null }
 };
 
 namespace Budgie {
@@ -65,7 +67,7 @@ public static int main(string[] args) {
 	}
 
 	/* Initialise wnck after gtk-start */
-	Idle.add(()=> {
+	Idle.add(() => {
 		screen = Wnck.Screen.get_default();
 		if (screen != null) {
 			screen.force_update();

--- a/src/daemon/manager.vala
+++ b/src/daemon/manager.vala
@@ -28,7 +28,7 @@ namespace Budgie {
 		*/
 		public ServiceManager(bool replace) {
 			theme_manager = new Budgie.ThemeManager();
-			register_with_session.begin((o,res)=> {
+			register_with_session.begin((o, res) => {
 				bool success = register_with_session.end(res);
 				if (!success) {
 					message("Failed to register with Session manager");
@@ -52,13 +52,13 @@ namespace Budgie {
 				return false;
 			}
 
-			sclient.QueryEndSession.connect(()=> {
+			sclient.QueryEndSession.connect(() => {
 				end_session(false);
 			});
-			sclient.EndSession.connect(()=> {
+			sclient.EndSession.connect(() => {
 				end_session(false);
 			});
-			sclient.Stop.connect(()=> {
+			sclient.Stop.connect(() => {
 				end_session(true);
 			});
 			return true;

--- a/src/daemon/menus.vala
+++ b/src/daemon/menus.vala
@@ -1,8 +1,8 @@
 /*
  * This file is part of budgie-desktop
- * 
+ *
  * Copyright © 2016-2019 Budgie Desktop Developers
- * 
+ *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
@@ -13,7 +13,7 @@ namespace Budgie {
 	/**
 	* Our name on the session bus. Reserved for Budgie use
 	*/
-	public const string MENU_DBUS_NAME		  = "org.budgie_desktop.MenuManager";
+	public const string MENU_DBUS_NAME = "org.budgie_desktop.MenuManager";
 
 	/**
 	* Unique object path on OSD_DBUS_NAME
@@ -25,14 +25,14 @@ namespace Budgie {
 	* BudgieMenuManager is responsible for managing the right click menus of
 	* the budgie desktop over dbus, so that GTK+ isn't used inside the WM process
 	*/
-	[DBus (name = "org.budgie_desktop.MenuManager")]
+	[DBus (name="org.budgie_desktop.MenuManager")]
 	public class MenuManager {
 		private Gtk.Menu? desktop_menu = null;
 		private unowned Wnck.Window? active_window = null;
 		private Wnck.ActionMenu? action_menu = null;
 		private uint32 xid = 0;
 
-		[DBus (visible = false)]
+		[DBus (visible=false)]
 		public MenuManager() {
 			init_desktop_menu();
 		}
@@ -104,7 +104,7 @@ namespace Budgie {
 		/**
 		* Own the MENU_DBUS_NAME
 		*/
-		[DBus (visible = false)]
+		[DBus (visible=false)]
 		public void setup_dbus(bool replace) {
 			var flags = BusNameOwnerFlags.ALLOW_REPLACEMENT;
 			if (replace) {
@@ -131,7 +131,7 @@ namespace Budgie {
 		* which contains actions for launching the settings, etc.
 		*/
 		public void ShowDesktopMenu(uint button, uint32 timestamp) {
-			Idle.add(()=> {
+			Idle.add(() => {
 				if (desktop_menu.get_visible()) {
 					desktop_menu.hide();
 				} else {

--- a/src/daemon/osd.vala
+++ b/src/daemon/osd.vala
@@ -1,8 +1,8 @@
 /*
  * This file is part of budgie-desktop
- * 
+ *
  * Copyright © 2016-2019 Budgie Desktop Developers
- * 
+ *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
@@ -23,7 +23,7 @@ namespace Budgie {
 	/**
 	* Our name on the session bus. Reserved for Budgie use
 	*/
-	public const string OSD_DBUS_NAME		 = "org.budgie_desktop.BudgieOSD";
+	public const string OSD_DBUS_NAME = "org.budgie_desktop.BudgieOSD";
 
 	/**
 	* Unique object path on OSD_DBUS_NAME
@@ -48,7 +48,7 @@ namespace Budgie {
 	* meaning subsequent requests to the OSD will keep it on screen in a natural fashion, allowing
 	* users to "hold down" the volume change buttons, for example.
 	*/
-	[GtkTemplate (ui = "/com/solus-project/budgie/daemon/osd.ui")]
+	[GtkTemplate (ui="/com/solus-project/budgie/daemon/osd.ui")]
 	public class OSD : Gtk.Window {
 		/**
 		* Main text display
@@ -184,12 +184,12 @@ namespace Budgie {
 	* BudgieOSDManager is responsible for managing the BudgieOSD over d-bus, receiving
 	* requests, for example, from budgie-wm
 	*/
-	[DBus (name = "org.budgie_desktop.BudgieOSD")]
+	[DBus (name="org.budgie_desktop.BudgieOSD")]
 	public class OSDManager {
 		private OSD? osd_window = null;
 		private uint32 expire_timeout = 0;
 
-		[DBus (visible = false)]
+		[DBus (visible=false)]
 		public OSDManager() {
 			osd_window = new OSD();
 		}
@@ -197,7 +197,7 @@ namespace Budgie {
 		/**
 		* Own the OSD_DBUS_NAME
 		*/
-		[DBus (visible = false)]
+		[DBus (visible=false)]
 		public void setup_dbus(bool replace) {
 			var flags = BusNameOwnerFlags.ALLOW_REPLACEMENT;
 			if (replace) {

--- a/src/daemon/settings.vala
+++ b/src/daemon/settings.vala
@@ -10,8 +10,8 @@
  */
 
 namespace Budgie {
-	[DBus (name = "org.gnome.SettingsDaemon.Power.Screen")]
-	interface PowerScreen : Object {
+	[DBus (name="org.gnome.SettingsDaemon.Power.Screen")]
+	interface PowerScreen : GLib.Object {
 		public abstract int32 brightness {owned get; set;}
 	}
 
@@ -81,7 +81,7 @@ namespace Budgie {
 			wm_settings = new Settings("com.solus-project.budgie-wm");
 
 			try {
-				gnome_power_props = Bus.get_proxy_sync (BusType.SESSION, "org.gnome.SettingsDaemon.Power", "/org/gnome/SettingsDaemon/Power");
+				gnome_power_props = Bus.get_proxy_sync(BusType.SESSION, "org.gnome.SettingsDaemon.Power", "/org/gnome/SettingsDaemon/Power");
 			} catch (IOError e) {
 				warning("Failed to acquire bus for org.gnome.SettingsDaemon.Power: %s\n", e.message);
 			}
@@ -113,7 +113,7 @@ namespace Budgie {
 		/**
 		* change_brightness will attempt to change our brightness in the power properties
 		*/
-		private void change_brightness (int32 value) {
+		private void change_brightness(int32 value) {
 			if (this.gnome_power_props != null) {
 				try {
 					this.gnome_power_props.brightness = value;

--- a/src/daemon/tabswitcher.vala
+++ b/src/daemon/tabswitcher.vala
@@ -80,7 +80,7 @@ namespace Budgie {
 	/**
 	*
 	*/
-	[GtkTemplate (ui = "/com/solus-project/budgie/daemon/tabswitcher.ui")]
+	[GtkTemplate (ui="/com/solus-project/budgie/daemon/tabswitcher.ui")]
 	public class TabSwitcherWindow : Gtk.Window {
 		[GtkChild]
 		private Gtk.FlowBox window_box;
@@ -93,7 +93,7 @@ namespace Budgie {
 		*/
 		private Gdk.Monitor primary_monitor;
 
-		private HashTable<uint32, TabSwitcherWidget?> xids = null;
+		private HashTable<uint32,TabSwitcherWidget?> xids = null;
 
 		private Budgie.AppSystem? app_system = null;
 
@@ -136,7 +136,7 @@ namespace Budgie {
 		public TabSwitcherWindow() {
 			Object(type: Gtk.WindowType.POPUP, type_hint: Gdk.WindowTypeHint.NOTIFICATION);
 			set_position(Gtk.WindowPosition.CENTER_ALWAYS);
-			this.xids = new HashTable<uint32, TabSwitcherWidget?>(GLib.direct_hash, GLib.direct_equal);
+			this.xids = new HashTable<uint32,TabSwitcherWidget?>(direct_hash, direct_equal);
 			this.app_system = new Budgie.AppSystem();
 
 			this.hide.connect(this.on_hide);
@@ -235,12 +235,12 @@ namespace Budgie {
 	* TabSwitcher is responsible for managing the BudgieSwitcher over d-bus, receiving
 	* requests, for example, from budgie-wm
 	*/
-	[DBus (name = "org.budgie_desktop.TabSwitcher")]
-	public class TabSwitcher : Object {
+	[DBus (name="org.budgie_desktop.TabSwitcher")]
+	public class TabSwitcher : GLib.Object {
 		private TabSwitcherWindow? switcher_window = null;
 		private uint32 mod_timeout = 0;
 
-		[DBus (visible = false)]
+		[DBus (visible=false)]
 		public TabSwitcher() {
 			switcher_window = new TabSwitcherWindow();
 		}
@@ -248,7 +248,7 @@ namespace Budgie {
 		/**
 		* Own the SWITCHER_DBUS_NAME
 		*/
-		[DBus (visible = false)]
+		[DBus (visible=false)]
 		public void setup_dbus(bool replace) {
 			var flags = BusNameOwnerFlags.ALLOW_REPLACEMENT;
 			if (replace) {
@@ -295,11 +295,11 @@ namespace Budgie {
 		}
 
 		private void add_mod_key_watcher() {
-			if(mod_timeout != 0){
+			if (mod_timeout != 0) {
 				Source.remove(mod_timeout);
 				mod_timeout = 0;
 			}
-			mod_timeout = Timeout.add(SWITCHER_MOD_EXPIRE_TIME, (GLib.SourceFunc)this.check_mod_key);
+			mod_timeout = Timeout.add(SWITCHER_MOD_EXPIRE_TIME, (SourceFunc)this.check_mod_key);
 		}
 
 		private bool check_mod_key() {

--- a/src/lib/animation.vala
+++ b/src/lib/animation.vala
@@ -1,6 +1,6 @@
 /*
  * This file is part of budgie-desktop
- * 
+ *
  * Copyright © 2015-2019 Budgie Desktop Developers
  *
  * This library is free software; you can redistribute it and/or
@@ -19,26 +19,26 @@ namespace Budgie {
 	/** Animate a GObject property */
 	public struct PropChange {
 		string property; /**<GObject property name */
-		Value old;		 /**<Value pre-animation */
-		Value @new;		 /**<Target value for end of animation */
+		Value old; /**<Value pre-animation */
+		Value @new; /**<Target value for end of animation */
 	}
 
 	/**
 	* Utility to struct to enable easier animations
-	* Inspired by Clutter. 
+	* Inspired by Clutter.
 	*/
 	[Compact]
-	public class Animation : Object {
-		public int64 start_time;		   /**<Start time (microseconds) of animation */
-		public int64 length;			   /**<Length of animation in microseconds */
-		public unowned TweenFunc tween;	   /**<Tween function to use for property changes */
-		public PropChange[] changes;	  /**<Group of properties to change in this animation */
+	public class Animation : GLib.Object {
+		public int64 start_time; /**<Start time (microseconds) of animation */
+		public int64 length; /**<Length of animation in microseconds */
+		public unowned TweenFunc tween; /**<Tween function to use for property changes */
+		public PropChange[] changes; /**<Group of properties to change in this animation */
 		public unowned Gtk.Widget widget;/**<Rendering widget that owns the Gdk.FrameClock */
-		public GLib.Object? object;		   /**<Widget to apply property changes to */
-		public uint id;					   /**<Idle source ID */
-		public bool can_anim;			   /**<Whether we can animate ?*/
-		public int64 elapsed;			  /**<Elapsed time */
-		public bool no_reset;			  /**<Used sometimes for switching an animation*/
+		public Object? object; /**<Widget to apply property changes to */
+		public uint id; /**<Idle source ID */
+		public bool can_anim; /**<Whether we can animate ?*/
+		public int64 elapsed; /**<Elapsed time */
+		public bool no_reset; /**<Used sometimes for switching an animation*/
 		private AnimCompletionFunc compl;
 
 		private bool tick_callback(Gtk.Widget widget, Gdk.FrameClock frame) {

--- a/src/lib/manager.vala
+++ b/src/lib/manager.vala
@@ -15,8 +15,8 @@ namespace Budgie {
 		public signal void panel_deleted(string uuid);
 		public signal void panel_added(string uuid, Budgie.Toplevel toplevel);
 
-		public virtual GLib.List<Budgie.Toplevel?> get_panels() {
-			return new GLib.List<Budgie.Toplevel?>();
+		public virtual List<Budgie.Toplevel?> get_panels() {
+			return new List<Budgie.Toplevel?>();
 		}
 
 		public abstract uint slots_available();
@@ -29,7 +29,7 @@ namespace Budgie {
 
 		public abstract void create_new_panel();
 		public abstract void delete_panel(string uuid);
-		public abstract GLib.List<Peas.PluginInfo?> get_panel_plugins();
+		public abstract List<Peas.PluginInfo?> get_panel_plugins();
 
 	}
 }

--- a/src/lib/shadow.vala
+++ b/src/lib/shadow.vala
@@ -78,7 +78,7 @@ namespace Budgie {
 				nat = 5;
 				return;
 			}
-			min = nat =	 rm;
+			min = nat = rm;
 		}
 
 		public override void get_preferred_width(out int min, out int nat) {

--- a/src/lib/toplevel.vala
+++ b/src/lib/toplevel.vala
@@ -51,7 +51,7 @@ namespace Budgie {
 		public Budgie.AutohidePolicy autohide { public set; public get; default = Budgie.AutohidePolicy.NONE; }
 
 
-		public abstract GLib.List<Budgie.AppletInfo?> get_applets();
+		public abstract List<Budgie.AppletInfo?> get_applets();
 		public signal void applet_added(Budgie.AppletInfo? info);
 		public signal void applet_removed(string uuid);
 
@@ -136,15 +136,15 @@ namespace Budgie {
 
 	[Flags]
 	public enum PanelTransparency {
-		NONE		= 1 << 0,
-		DYNAMIC		= 1 << 1,
-		ALWAYS		= 1 << 2
+		NONE = 1 << 0,
+		DYNAMIC = 1 << 1,
+		ALWAYS = 1 << 2
 	}
 
 	[Flags]
 	public enum AutohidePolicy {
-		NONE		= 1 << 0,
-		AUTOMATIC	= 1 << 1,
+		NONE = 1 << 0,
+		AUTOMATIC = 1 << 1,
 		INTELLIGENT = 1 << 2
 	}
 

--- a/src/libsession/libsession.vala
+++ b/src/libsession/libsession.vala
@@ -14,12 +14,12 @@ namespace LibSession {
 	 * Proxy for gnome-session
 	 */
 	[DBus (name="org.gnome.SessionManager")]
-	public interface SessionManager : Object {
+	public interface SessionManager : GLib.Object {
 		public abstract async ObjectPath RegisterClient(string app_id, string client_start_id) throws IOError;
 	}
 
 	[DBus (name="org.gnome.SessionManager.ClientPrivate")]
-	public interface SessionClient : Object {
+	public interface SessionClient : GLib.Object {
 		public abstract void EndSessionResponse(bool is_ok, string reason) throws IOError;
 
 		public signal void Stop() ;

--- a/src/panel/budgie-desktop-settings.vala
+++ b/src/panel/budgie-desktop-settings.vala
@@ -1,19 +1,19 @@
 /*
  * This file is part of budgie-desktop
- * 
+ *
  * Copyright © 2015-2019 Budgie Desktop Developers
- * 
+ *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
  * (at your option) any later version.
  */
 
-public const string PANEL_DBUS_NAME		   = "org.budgie_desktop.Panel";
+public const string PANEL_DBUS_NAME = "org.budgie_desktop.Panel";
 public const string PANEL_DBUS_OBJECT_PATH = "/org/budgie_desktop/Panel";
 
-[DBus (name = "org.budgie_desktop.Panel")]
-public interface PanelRemote : Object {
+[DBus (name="org.budgie_desktop.Panel")]
+public interface PanelRemote : GLib.Object {
 	public abstract void OpenSettings() throws Error;
 }
 

--- a/src/panel/main.vala
+++ b/src/panel/main.vala
@@ -1,8 +1,8 @@
 /*
  * This file is part of budgie-desktop
- * 
+ *
  * Copyright © 2015-2019 Budgie Desktop Developers
- * 
+ *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
@@ -12,9 +12,9 @@
 static bool replace = false;
 static bool reset = false;
 
-const GLib.OptionEntry[] options = { 
-	{ "replace", 0, 0, OptionArg.NONE, ref replace, "Replace currently running panel" }, 
-	{ "reset", 0, 0, OptionArg.NONE, ref reset, "Reset the panel configuration" }, 
+const OptionEntry[] options = {
+	{ "replace", 0, 0, OptionArg.NONE, ref replace, "Replace currently running panel" },
+	{ "reset", 0, 0, OptionArg.NONE, ref reset, "Reset the panel configuration" },
 	{ null }
 };
 

--- a/src/panel/manager.vala
+++ b/src/panel/manager.vala
@@ -1,18 +1,18 @@
 /*
  * This file is part of budgie-desktop
- * 
+ *
  * Copyright © 2015-2019 Budgie Desktop Developers
- * 
+ *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
  * (at your option) any later version.
  */
- 
+
 using LibUUID;
 
 namespace Budgie {
-	public const string DBUS_NAME		 = "org.budgie_desktop.Panel";
+	public const string DBUS_NAME = "org.budgie_desktop.Panel";
 	public const string DBUS_OBJECT_PATH = "/org/budgie_desktop/Panel";
 
 	public const string MIGRATION_1_APPLETS[] = {
@@ -24,7 +24,7 @@ namespace Budgie {
 	* Available slots
 	*/
 	[Compact]
-	class Screen : Object {
+	class Screen : GLib.Object {
 		public PanelPosition slots;
 		public Gdk.Rectangle area;
 	}
@@ -32,12 +32,12 @@ namespace Budgie {
 	/**
 	* Permit a slot for each edge of the screen
 	*/
-	public const uint MAX_SLOTS			= 4;
+	public const uint MAX_SLOTS = 4;
 
 	/**
 	* Root prefix for fixed schema
 	*/
-	public const string ROOT_SCHEMA		= "com.solus-project.budgie-panel";
+	public const string ROOT_SCHEMA = "com.solus-project.budgie-panel";
 
 	/**
 	* Relocatable schema ID for toplevel panels
@@ -53,50 +53,50 @@ namespace Budgie {
 	/**
 	* Relocatable schema ID for applets
 	*/
-	public const string APPLET_SCHEMA	= "com.solus-project.budgie-panel.applet";
+	public const string APPLET_SCHEMA = "com.solus-project.budgie-panel.applet";
 
 	/**
 	* Prefix for all relocatable applet settings
 	*/
-	public const string APPLET_PREFIX	= "/com/solus-project/budgie-panel/applets";
+	public const string APPLET_PREFIX = "/com/solus-project/budgie-panel/applets";
 
 	/**
 	* Known panels
 	*/
-	public const string ROOT_KEY_PANELS		   = "panels";
+	public const string ROOT_KEY_PANELS = "panels";
 
 	/** Panel position */
-	public const string PANEL_KEY_POSITION	   = "location";
+	public const string PANEL_KEY_POSITION = "location";
 
 	/** Panel transparency */
 	public const string PANEL_KEY_TRANSPARENCY = "transparency";
 
 	/** Panel applets */
-	public const string PANEL_KEY_APPLETS	   = "applets";
+	public const string PANEL_KEY_APPLETS = "applets";
 
 	/** Night mode/dark theme */
-	public const string PANEL_KEY_DARK_THEME   = "dark-theme";
+	public const string PANEL_KEY_DARK_THEME = "dark-theme";
 
 	/** Panel size */
-	public const string PANEL_KEY_SIZE		   = "size";
+	public const string PANEL_KEY_SIZE = "size";
 
 	/** Autohide policy */
-	public const string PANEL_KEY_AUTOHIDE	   = "autohide";
+	public const string PANEL_KEY_AUTOHIDE = "autohide";
 
 	/** Shadow */
-	public const string PANEL_KEY_SHADOW	   = "enable-shadow";
+	public const string PANEL_KEY_SHADOW = "enable-shadow";
 
 	/** Dock mode */
-	public const string PANEL_KEY_DOCK_MODE	   = "dock-mode";
+	public const string PANEL_KEY_DOCK_MODE = "dock-mode";
 
 	/** Theme regions permitted? */
-	public const string PANEL_KEY_REGIONS	   = "theme-regions";
+	public const string PANEL_KEY_REGIONS = "theme-regions";
 
 	/** Current migration level in settings */
-	public const string PANEL_KEY_MIGRATION	   = "migration-level";
+	public const string PANEL_KEY_MIGRATION = "migration-level";
 
 	/** Layout to select when reset/init for the first time */
-	public const string PANEL_KEY_LAYOUT	   = "layout";
+	public const string PANEL_KEY_LAYOUT = "layout";
 
 	/**
 	* The current migration level of Budgie, or format change, if you will.
@@ -104,11 +104,11 @@ namespace Budgie {
 	public const int BUDGIE_MIGRATION_LEVEL = 1;
 
 
-	[DBus (name = "org.budgie_desktop.Panel")]
+	[DBus (name="org.budgie_desktop.Panel")]
 	public class PanelManagerIface {
 		private Budgie.PanelManager? manager = null;
 
-		[DBus (visible = false)]
+		[DBus (visible=false)]
 		public PanelManagerIface(Budgie.PanelManager? manager) {
 			this.manager = manager;
 		}
@@ -142,7 +142,7 @@ namespace Budgie {
 		Peas.Engine engine;
 		Peas.ExtensionSet extensions;
 
-		HashTable<string, Peas.PluginInfo?> plugins;
+		HashTable<string,Peas.PluginInfo?> plugins;
 
 		private Budgie.Raven? raven = null;
 
@@ -193,13 +193,13 @@ namespace Budgie {
 				return false;
 			}
 
-			sclient.QueryEndSession.connect(()=> {
+			sclient.QueryEndSession.connect(() => {
 				end_session(false);
 			});
-			sclient.EndSession.connect(()=> {
+			sclient.EndSession.connect(() => {
 				end_session(false);
 			});
-			sclient.Stop.connect(()=> {
+			sclient.Stop.connect(() => {
 				end_session(true);
 			});
 			return true;
@@ -363,11 +363,11 @@ namespace Budgie {
 		/*
 		* Decide wether or not the panel should be opaque
 		* The panel should be opaque when:
-		*	 - Raven is open
-		*	 - a window fills these requirements:
-		*	   - Maximized horizontally or verically
-		*	   - Not minimized/iconified
-		*	   - On the current active workspace
+		* - Raven is open
+		* - a window fills these requirements:
+		*   - Maximized horizontally or verically
+		*   - Not minimized/iconified
+		*   - On the current active workspace
 		*/
 		public void check_windows() {
 			if (raven.get_expanded()) {
@@ -529,7 +529,7 @@ namespace Budgie {
 		* Reset the entire panel configuration
 		*/
 		void do_reset() {
-			GLib.message("Resetting budgie-panel configuration to defaults");
+			message("Resetting budgie-panel configuration to defaults");
 			Settings s = new Settings(Budgie.ROOT_SCHEMA);
 			this.default_layout = s.get_string(PANEL_KEY_LAYOUT);
 			this.reset_dconf_path(s);
@@ -542,7 +542,7 @@ namespace Budgie {
 		* Reset after a failed load
 		*/
 		void do_live_reset() {
-			GLib.message("Resetting budgie-panel configuration due to failed load");
+			message("Resetting budgie-panel configuration due to failed load");
 
 			string[]? toplevel_ids = null;
 
@@ -572,7 +572,7 @@ namespace Budgie {
 			scr.monitors_changed.connect(this.on_monitors_changed);
 			scr.size_changed.connect(this.on_monitors_changed);
 
-			settings = new GLib.Settings(Budgie.ROOT_SCHEMA);
+			settings = new Settings(Budgie.ROOT_SCHEMA);
 			this.default_layout = settings.get_string(PANEL_KEY_LAYOUT);
 			theme_manager = new Budgie.ThemeManager();
 			raven = new Budgie.Raven(this);
@@ -603,7 +603,7 @@ namespace Budgie {
 			/* Whatever route we took, set the migration level to the current now */
 			settings.set_int(PANEL_KEY_MIGRATION, BUDGIE_MIGRATION_LEVEL);
 
-			register_with_session.begin((o,res)=> {
+			register_with_session.begin((o, res) => {
 				bool success = register_with_session.end(res);
 				if (!success) {
 					message("Failed to register with Session manager");
@@ -648,7 +648,7 @@ namespace Budgie {
 				last = top;
 			}
 
-			/* Ask this panel to perform migratory tasks (add applets) */
+			/* Ask this panel to perform migratory tasks(add applets) */
 			(last as Budgie.Panel).perform_migration(current_migration_level);
 		}
 
@@ -690,7 +690,7 @@ namespace Budgie {
 			extensions = new Peas.ExtensionSet(engine, typeof(Budgie.Plugin));
 
 			extensions.extension_added.connect(on_extension_added);
-			engine.load_plugin.connect_after((i)=> {
+			engine.load_plugin.connect_after((i) => {
 				Peas.Extension? e = extensions.get_extension(i);
 				if (e == null) {
 					critical("Failed to find extension for: %s", i.get_name());
@@ -736,8 +736,8 @@ namespace Budgie {
 			return true;
 		}
 
-		public override GLib.List<Peas.PluginInfo?> get_panel_plugins() {
-			GLib.List<Peas.PluginInfo?> ret = new GLib.List<Peas.PluginInfo?>();
+		public override List<Peas.PluginInfo?> get_panel_plugins() {
+			List<Peas.PluginInfo?> ret = new List<Peas.PluginInfo?>();
 			foreach (unowned Peas.PluginInfo? info in this.engine.get_plugin_list()) {
 				ret.append(info);
 			}
@@ -768,9 +768,9 @@ namespace Budgie {
 		/**
 		* Attempt to load plugin, will set the plugin-name on failure
 		*/
-		public Budgie.AppletInfo? load_applet_instance(string? uuid, out string name, GLib.Settings? psettings = null) {
+		public Budgie.AppletInfo? load_applet_instance(string? uuid, out string name, Settings? psettings = null) {
 			var path = this.create_applet_path(uuid);
-			GLib.Settings? settings = null;
+			Settings? settings = null;
 			if (psettings == null) {
 				settings = new Settings.with_path(Budgie.APPLET_SCHEMA, path);
 			} else {
@@ -868,7 +868,7 @@ namespace Budgie {
 			AutohidePolicy policy;
 			int size;
 
-			var settings = new GLib.Settings.with_path(Budgie.TOPLEVEL_SCHEMA, path);
+			var settings = new Settings.with_path(Budgie.TOPLEVEL_SCHEMA, path);
 			Budgie.Panel? panel = new Budgie.Panel(this, uuid, settings);
 			panels.insert(uuid, panel);
 
@@ -1304,7 +1304,7 @@ namespace Budgie {
 				}
 			}
 
-			GLib.warning("Failed to find layout '%s'", layout_name);
+			warning("Failed to find layout '%s'", layout_name);
 
 			// Absolute fallback = built in INI config
 			this.load_default_from_config("resource:///com/solus-project/budgie/panel/panel.ini");
@@ -1317,14 +1317,14 @@ namespace Budgie {
 		void create_system_default() {
 			/**
 			* Try in order, and load the first one that exists:
-			*	- /etc/budgie-desktop/panel.ini
-			*	- /usr/share/budgie-desktop/panel.ini
-			*	- Built in panel.ini
+			* - /etc/budgie-desktop/panel.ini
+			* - /usr/share/budgie-desktop/panel.ini
+			* - Built in panel.ini
 			*/
 			string[] system_configs = {
-					@"file://$(Budgie.CONFDIR)/budgie-desktop/panel.ini",
-					@"file://$(Budgie.DATADIR)/budgie-desktop/panel.ini",
-					""
+				@"file://$(Budgie.CONFDIR)/budgie-desktop/panel.ini",
+				@"file://$(Budgie.DATADIR)/budgie-desktop/panel.ini",
+				""
 			};
 
 			foreach (string? filepath in system_configs) {
@@ -1406,8 +1406,8 @@ namespace Budgie {
 				on_bus_acquired, on_name_acquired, on_name_lost);
 		}
 
-		public override GLib.List<Budgie.Toplevel?> get_panels() {
-			var list = new GLib.List<Budgie.Toplevel?>();
+		public override List<Budgie.Toplevel?> get_panels() {
+			var list = new List<Budgie.Toplevel?>();
 			unowned string? key;
 			unowned Budgie.Panel? panel;
 			var iter = HashTableIter<string?,Budgie.Panel?>(panels);
@@ -1426,10 +1426,10 @@ namespace Budgie {
 		* Open up the settings window on screen
 		*/
 		public void open_settings() {
-			Idle.add(()=> {
+			Idle.add(() => {
 				if (this.settings_window == null) {
 					this.settings_window = new Budgie.SettingsWindow(this);
-					this.settings_window.destroy.connect(()=> {
+					this.settings_window.destroy.connect(() => {
 						this.settings_window = null;
 					});
 

--- a/src/panel/panel.vala
+++ b/src/panel/panel.vala
@@ -1,8 +1,8 @@
 /*
  * This file is part of budgie-desktop
- * 
+ *
  * Copyright © 2015-2019 Budgie Desktop Developers
- * 
+ *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
@@ -126,7 +126,7 @@ namespace Budgie {
 				if ((info.applet.supported_actions & action) != 0) {
 					this.present();
 
-					Idle.add(()=> {
+					Idle.add(() => {
 						info.applet.invoke_action(action);
 						return false;
 					});
@@ -205,8 +205,8 @@ namespace Budgie {
 			this.update_dock_behavior();
 		}
 
-		public override GLib.List<AppletInfo?> get_applets() {
-			GLib.List<Budgie.AppletInfo?> ret = new GLib.List<Budgie.AppletInfo?>();
+		public override List<AppletInfo?> get_applets() {
+			List<Budgie.AppletInfo?> ret = new List<Budgie.AppletInfo?>();
 			unowned string? key = null;
 			unowned Budgie.AppletInfo? appl_info = null;
 
@@ -282,12 +282,12 @@ namespace Budgie {
 			nscale = 1.0;
 
 			// Respond to a scale factor change
-			notify["scale-factor"].connect(()=> {
+			notify["scale-factor"].connect(() => {
 				this.scale = get_scale_factor();
 				this.placement();
 			});
 			// Handle intelligent dock behavior
-			notify["intersected"].connect(()=> {
+			notify["intersected"].connect(() => {
 				if (this.autohide != AutohidePolicy.NONE) {
 					this.update_dock_behavior();
 				}
@@ -509,7 +509,7 @@ namespace Budgie {
 					if (info == null) {
 						/* Faiiiil */
 						if (name == null) {
-							unowned List<string?> g = expected_uuids.find_custom(applets[i], GLib.strcmp);
+							unowned List<string?> g = expected_uuids.find_custom(applets[i], strcmp);
 							/* TODO: No longer expecting this guy to load */
 							if (g != null) {
 								expected_uuids.remove_link(g);
@@ -747,7 +747,7 @@ namespace Budgie {
 
 			if (!this.is_fully_loaded) {
 				lock (expected_uuids) {
-					unowned List<string?> exp_fin = expected_uuids.find_custom(info.uuid, GLib.strcmp);
+					unowned List<string?> exp_fin = expected_uuids.find_custom(info.uuid, strcmp);
 					if (exp_fin != null) {
 						expected_uuids.remove_link(exp_fin);
 					}
@@ -954,7 +954,7 @@ namespace Budgie {
 			if (this.dock_mode) {
 				switch (position) {
 				case Budgie.PanelPosition.TOP:
-					x = (orig_scr.x / 2) + (((orig_scr.x + orig_scr.width) / 2)	 - (alloc.width / 2));
+					x = (orig_scr.x / 2) + (((orig_scr.x + orig_scr.width) / 2) - (alloc.width / 2));
 					if (x < orig_scr.x) {
 						x = orig_scr.x;
 					}
@@ -976,7 +976,7 @@ namespace Budgie {
 					break;
 				case Budgie.PanelPosition.BOTTOM:
 				default:
-					x = (orig_scr.x / 2) + (((orig_scr.x + orig_scr.width) / 2)	 - (alloc.width / 2));
+					x = (orig_scr.x / 2) + (((orig_scr.x + orig_scr.width) / 2) - (alloc.width / 2));
 					y = orig_scr.y + (orig_scr.height - intended_size);
 					if (x < orig_scr.x) {
 						x = orig_scr.x;
@@ -1565,7 +1565,7 @@ namespace Budgie {
 				}
 			};
 
-			dock_animation.start((a)=> {
+			dock_animation.start((a) => {
 				this.set_input_region();
 				this.animation = PanelAnimation.NONE;
 			});
@@ -1608,7 +1608,7 @@ namespace Budgie {
 				}
 			};
 
-			dock_animation.start((a)=> {
+			dock_animation.start((a) => {
 				this.unset_input_region();
 				this.animation = PanelAnimation.NONE;
 			});
@@ -1673,12 +1673,12 @@ namespace Budgie {
 		*/
 		public void perform_migration(int current_migration_level) {
 			if (current_migration_level != 0) {
-				GLib.warning("Unknown migration level: %d", current_migration_level);
+				warning("Unknown migration level: %d", current_migration_level);
 				return;
 			}
 			this.need_migratory = true;
 			if (this.is_fully_loaded) {
-				GLib.message("Performing migration to level %d", BUDGIE_MIGRATION_LEVEL);
+				message("Performing migration to level %d", BUDGIE_MIGRATION_LEVEL);
 				this.add_migratory();
 			}
 		}

--- a/src/panel/settings/settings_applet_chooser.vala
+++ b/src/panel/settings/settings_applet_chooser.vala
@@ -1,8 +1,8 @@
 /*
  * This file is part of budgie-desktop
- * 
+ *
  * Copyright © 2015-2019 Budgie Desktop Developers
- * 
+ *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
@@ -118,7 +118,7 @@ namespace Budgie {
 			Peas.PluginInfo? infoA = (a.get_child() as PluginItem).plugin;
 			Peas.PluginInfo? infoB = (b.get_child() as PluginItem).plugin;
 
-			return GLib.strcmp(infoA.get_name().down(), infoB.get_name().down());
+			return strcmp(infoA.get_name().down(), infoB.get_name().down());
 		}
 
 		/**
@@ -151,7 +151,7 @@ namespace Budgie {
 		/**
 		* Set the available plugins to show in the dialog
 		*/
-		public void set_plugin_list(GLib.List<Peas.PluginInfo?> plugins) {
+		public void set_plugin_list(List<Peas.PluginInfo?> plugins) {
 			foreach (var child in applets.get_children()) {
 				child.destroy();
 			}

--- a/src/panel/settings/settings_autostart.vala
+++ b/src/panel/settings/settings_autostart.vala
@@ -24,7 +24,7 @@ namespace Budgie {
 		public string description;
 		public string command;
 		public string executable;
-		public GLib.Icon? icon = null;
+		public Icon? icon = null;
 
 		construct {
 			id = "";
@@ -35,7 +35,7 @@ namespace Budgie {
 			executable = "";
 		}
 
-		public AutostartItem.from_app_info(GLib.DesktopAppInfo info) {
+		public AutostartItem.from_app_info(DesktopAppInfo info) {
 			this.id = info.get_id() ?? "";
 			this.filename = info.get_filename() ?? "";
 			this.title = info.get_display_name() ?? "";
@@ -51,28 +51,28 @@ namespace Budgie {
 		}
 
 		public string? make_autostart() {
-			DirUtils.create_with_parents(GLib.Path.build_path("/", AutostartPage.AUTOSTART_PATH), 00755);
+			DirUtils.create_with_parents(Path.build_path("/", AutostartPage.AUTOSTART_PATH), 00755);
 			if (filename != "") {
-				string destination_path = GLib.Path.build_path("/", AutostartPage.AUTOSTART_PATH, GLib.Filename.display_basename(filename));
-				GLib.File destination = GLib.File.new_for_path(destination_path);
-				GLib.File file = GLib.File.new_for_path(filename);
+				string destination_path = Path.build_path("/", AutostartPage.AUTOSTART_PATH, Filename.display_basename(filename));
+				File destination = File.new_for_path(destination_path);
+				File file = File.new_for_path(filename);
 				try {
-					file.copy(destination, GLib.FileCopyFlags.NONE);
+					file.copy(destination, FileCopyFlags.NONE);
 					this.filename = destination_path;
-				} catch (GLib.Error e) {
+				} catch (Error e) {
 					warning(e.message);
 					return null;
 				}
 			} else if (command != "") {
-				string destination_path = GLib.Path.build_path("/", AutostartPage.AUTOSTART_PATH, @"$title.desktop");
-				GLib.File file = GLib.File.new_for_path(destination_path);
+				string destination_path = Path.build_path("/", AutostartPage.AUTOSTART_PATH, @"$title.desktop");
+				File file = File.new_for_path(destination_path);
 				try {
-					GLib.FileOutputStream file_stream = file.create(GLib.FileCreateFlags.NONE);
+					FileOutputStream file_stream = file.create(FileCreateFlags.NONE);
 					if (file.query_exists()) {
-						GLib.DataOutputStream data_stream = new GLib.DataOutputStream(file_stream);
+						DataOutputStream data_stream = new DataOutputStream(file_stream);
 						data_stream.put_string(@"[Desktop Entry]\nType=Application\nName=$title\nDescription=$description\nExec=$command\n");
 						this.filename = file.get_path();
-						GLib.DesktopAppInfo? info = new GLib.DesktopAppInfo.from_filename(file.get_path());
+						DesktopAppInfo? info = new DesktopAppInfo.from_filename(file.get_path());
 						if (info == null) {
 							this.delete();
 							return null;
@@ -81,7 +81,7 @@ namespace Budgie {
 					} else {
 						return null;
 					}
-				} catch (GLib.Error e) {
+				} catch (Error e) {
 					warning(e.message);
 					return null;
 				}
@@ -91,10 +91,10 @@ namespace Budgie {
 		}
 
 		public void delete() {
-			GLib.File file = GLib.File.new_for_path(filename);
+			File file = File.new_for_path(filename);
 			try {
 				file.delete();
-			} catch (GLib.Error e) {
+			} catch (Error e) {
 				warning(e.message);
 			}
 			AutostartPage.autostart_files.remove(this.id);
@@ -131,14 +131,14 @@ namespace Budgie {
 			text_box.valign = Gtk.Align.CENTER;
 
 			string title = item.title;
-			title = (title != "") ? GLib.Markup.escape_text(title) : "<i>" + _("Untitled") + "</i>";
+			title = (title != "") ? Markup.escape_text(title) : "<i>" + _("Untitled") + "</i>";
 			Gtk.Label title_label = new Gtk.Label(@"<big>$title</big>");
 			text_box.add(title_label);
 			title_label.set_use_markup(true);
 			title_label.halign = Gtk.Align.START;
 
 			string description = item.description;
-			description = (description != "") ? GLib.Markup.escape_text(description) : "<i>" + _("No description") + "</i>";
+			description = (description != "") ? Markup.escape_text(description) : "<i>" + _("No description") + "</i>";
 			Gtk.Label desc_label = new Gtk.Label(description);
 			text_box.add(desc_label);
 			desc_label.set_max_width_chars(35);
@@ -175,7 +175,7 @@ namespace Budgie {
 		private Gtk.ListBox app_listbox;
 		private Gtk.Widget button_ok;
 		private Gtk.SearchEntry search_entry;
-		private GLib.GenericSet<string> running_processes;
+		private GenericSet<string> running_processes;
 
 		private AutostartItem? selected_item = null;
 
@@ -185,7 +185,7 @@ namespace Budgie {
 				title: _("Applications"),
 				transient_for: parent);
 
-			running_processes = new GLib.GenericSet<string>(str_hash, str_equal);
+			running_processes = new GenericSet<string>(str_hash, str_equal);
 
 			get_running_processes();
 
@@ -232,7 +232,7 @@ namespace Budgie {
 			content_area.show_all();
 
 			set_default_size(400, 450);
-			set_app_list(GLib.AppInfo.get_all());
+			set_app_list(AppInfo.get_all());
 		}
 
 		private bool search_filter(Gtk.ListBoxRow row) {
@@ -257,7 +257,7 @@ namespace Budgie {
 				return 1;
 			}
 
-			return GLib.strcmp(item1.autostart_item.title, item2.autostart_item.title);
+			return strcmp(item1.autostart_item.title, item2.autostart_item.title);
 		}
 
 		public new AutostartItem? run() {
@@ -291,14 +291,14 @@ namespace Budgie {
 			}
 		}
 
-		private void set_app_list(GLib.List<GLib.AppInfo> app_list) {
+		private void set_app_list(List<AppInfo> app_list) {
 			foreach (var child in app_listbox.get_children()) {
 				child.destroy();
 			}
 
 			foreach (var app in app_list) {
 				if (app.should_show()) {
-					GLib.DesktopAppInfo? info = new GLib.DesktopAppInfo(app.get_id());
+					DesktopAppInfo? info = new DesktopAppInfo(app.get_id());
 					if (info != null) {
 						AutostartItem item = new AutostartItem.from_app_info(info);
 						bool running = running_processes.contains(item.executable);
@@ -315,9 +315,9 @@ namespace Budgie {
 			int ls_status;
 
 			try {
-				string username = GLib.Environment.get_user_name();
+				string username = Environment.get_user_name();
 				// Credit to gnome-tweak-tool for inspiration
-				GLib.Process.spawn_command_line_sync(@"ps -e -w -w -U $username -o cmd",
+				Process.spawn_command_line_sync(@"ps -e -w -w -U $username -o cmd",
 					out ls_stdout,
 					out ls_stderr,
 					out ls_status);
@@ -335,7 +335,7 @@ namespace Budgie {
 						}
 					}
 				}
-			} catch (GLib.SpawnError e) {
+			} catch (SpawnError e) {
 				warning(e.message);
 			}
 		}
@@ -437,7 +437,7 @@ namespace Budgie {
 	*/
 	public class AutostartPage : Budgie.SettingsPage {
 		private Gtk.ListBox listbox_autostart;
-		public static GLib.HashTable<string, string> autostart_files;
+		public static HashTable<string,string> autostart_files;
 		public static string AUTOSTART_PATH;
 
 		public AutostartPage() {
@@ -448,9 +448,9 @@ namespace Budgie {
 				icon_name: "preferences-other",
 				halign: Gtk.Align.FILL);
 
-			AUTOSTART_PATH = GLib.Path.build_path("/", GLib.Environment.get_user_config_dir(), "autostart");
+			AUTOSTART_PATH = Path.build_path("/", Environment.get_user_config_dir(), "autostart");
 
-			autostart_files = new GLib.HashTable<string, string>(str_hash, str_equal);
+			autostart_files = new HashTable<string,string>(str_hash, str_equal);
 
 			Gtk.Frame frame = new Gtk.Frame(null);
 			this.pack_start(frame, true, true, 0);
@@ -491,7 +491,7 @@ namespace Budgie {
 			list_directory.begin(AUTOSTART_PATH, (obj, res) => {
 				string[] files = list_directory.end(res);
 				foreach (string file in files) {
-					GLib.DesktopAppInfo? info = new GLib.DesktopAppInfo.from_filename(file);
+					DesktopAppInfo? info = new DesktopAppInfo.from_filename(file);
 					if (info != null) {
 						AutostartItem item = new AutostartItem.from_app_info(info);
 						add_item(item);
@@ -522,23 +522,23 @@ namespace Budgie {
 
 		private async string[] list_directory(string directory) {
 			string[] filelist = {};
-			GLib.File dir = GLib.File.new_for_path(directory);
+			File dir = File.new_for_path(directory);
 
 			try {
-				var e = yield dir.enumerate_children_async(GLib.FileAttribute.STANDARD_NAME, 0, GLib.Priority.DEFAULT);
+				var e = yield dir.enumerate_children_async(FileAttribute.STANDARD_NAME, 0, Priority.DEFAULT);
 				while (true) {
-					var files = yield e.next_files_async(10, GLib.Priority.DEFAULT);
+					var files = yield e.next_files_async(10, Priority.DEFAULT);
 					if (files == null) {
 						break;
 					}
-					foreach (GLib.FileInfo info in files) {
+					foreach (FileInfo info in files) {
 						if (info.get_name().has_suffix(".desktop")) {
-							string path = GLib.Path.build_path("/", directory, info.get_name());
+							string path = Path.build_path("/", directory, info.get_name());
 							filelist += path;
 						}
 					}
 				}
-			} catch (GLib.Error e) {
+			} catch (Error e) {
 				warning("Error: list_directory failed: %s\n", e.message);
 			}
 

--- a/src/panel/settings/settings_desktop.vala
+++ b/src/panel/settings/settings_desktop.vala
@@ -1,8 +1,8 @@
 /*
  * This file is part of budgie-desktop
- * 
+ *
  * Copyright © 2015-2019 Budgie Desktop Developers
- * 
+ *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
@@ -47,7 +47,7 @@ namespace Budgie {
 				_("Control whether to allow launchers and icons on the desktop.")));
 
 			/* Hook up settings */
-			bg_settings = new GLib.Settings("org.gnome.desktop.background");
+			bg_settings = new Settings("org.gnome.desktop.background");
 			bg_settings.bind("show-desktop-icons", switch_icons, "active", SettingsBindFlags.DEFAULT);
 			bg_settings.changed["show-desktop-icons"].connect(this.update_switches);
 
@@ -76,7 +76,7 @@ namespace Budgie {
 				_("Mounted volumes & drives will appear on the desktop.")));
 
 
-			nautilus_settings = new GLib.Settings("org.gnome.nautilus.desktop");
+			nautilus_settings = new Settings("org.gnome.nautilus.desktop");
 			nautilus_settings.bind("home-icon-visible", switch_home, "active", SettingsBindFlags.DEFAULT);
 			nautilus_settings.bind("network-icon-visible", switch_network, "active", SettingsBindFlags.DEFAULT);
 			nautilus_settings.bind("trash-icon-visible", switch_trash, "active", SettingsBindFlags.DEFAULT);

--- a/src/panel/settings/settings_fonts.vala
+++ b/src/panel/settings/settings_fonts.vala
@@ -133,9 +133,9 @@ namespace Budgie {
 			combobox_antialias.add_attribute(render, "text", 1);
 
 			/* Hook up settings */
-			ui_settings = new GLib.Settings("org.gnome.desktop.interface");
-			wm_settings = new GLib.Settings("org.gnome.desktop.wm.preferences");
-			x_settings = new GLib.Settings("org.gnome.settings-daemon.plugins.xsettings");
+			ui_settings = new Settings("org.gnome.desktop.interface");
+			wm_settings = new Settings("org.gnome.desktop.wm.preferences");
+			x_settings = new Settings("org.gnome.settings-daemon.plugins.xsettings");
 			ui_settings.bind("document-font-name", fontbutton_document, "font-name", SettingsBindFlags.DEFAULT);
 			ui_settings.bind("font-name", fontbutton_interface, "font-name", SettingsBindFlags.DEFAULT);
 			ui_settings.bind("monospace-font-name", fontbutton_monospace, "font-name", SettingsBindFlags.DEFAULT);

--- a/src/panel/settings/settings_item.vala
+++ b/src/panel/settings/settings_item.vala
@@ -1,8 +1,8 @@
 /*
  * This file is part of budgie-desktop
- * 
+ *
  * Copyright © 2015-2019 Budgie Desktop Developers
- * 
+ *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or

--- a/src/panel/settings/settings_main.vala
+++ b/src/panel/settings/settings_main.vala
@@ -1,8 +1,8 @@
 /*
  * This file is part of budgie-desktop
- * 
+ *
  * Copyright © 2015-2019 Budgie Desktop Developers
- * 
+ *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
@@ -114,7 +114,7 @@ namespace Budgie {
 		*/
 		void on_panels_changed() {
 			item_add_panel.set_sensitive(this.manager.slots_available() >= 1);
-			Idle.add(()=> {
+			Idle.add(() => {
 				this.sidebar.invalidate_sort();
 				this.sidebar.invalidate_filter();
 				return false;
@@ -254,7 +254,7 @@ namespace Budgie {
 		* Emulate sidebar activation for the user
 		*/
 		void force_select_page(string content_id) {
-			Idle.add(()=> {
+			Idle.add(() => {
 				Gtk.ListBoxRow? row = this.sidebar_map[content_id].get_parent() as Gtk.ListBoxRow;
 				sidebar.select_row(row);
 				row.grab_focus();

--- a/src/panel/settings/settings_page.vala
+++ b/src/panel/settings/settings_page.vala
@@ -1,8 +1,8 @@
 /*
  * This file is part of budgie-desktop
- * 
+ *
  * Copyright © 2015-2019 Budgie Desktop Developers
- * 
+ *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or

--- a/src/panel/settings/settings_panel.vala
+++ b/src/panel/settings/settings_panel.vala
@@ -1,8 +1,8 @@
 /*
  * This file is part of budgie-desktop
- * 
+ *
  * Copyright © 2015-2019 Budgie Desktop Developers
- * 
+ *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or

--- a/src/panel/settings/settings_panel_applets.vala
+++ b/src/panel/settings/settings_panel_applets.vala
@@ -1,8 +1,8 @@
 /*
  * This file is part of budgie-desktop
- * 
+ *
  * Copyright © 2015-2019 Budgie Desktop Developers
- * 
+ *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
@@ -116,7 +116,7 @@ namespace Budgie {
 				this.applet_added(applet);
 			}
 
-			Idle.add(()=> {
+			Idle.add(() => {
 				this.settings_stack.set_visible_child_name("main");
 				return false;
 			});

--- a/src/panel/settings/settings_panel_dialogs.vala
+++ b/src/panel/settings/settings_panel_dialogs.vala
@@ -1,8 +1,8 @@
 /*
  * This file is part of budgie-desktop
- * 
+ *
  * Copyright © 2017-2019 Budgie Desktop Developers
- * 
+ *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or

--- a/src/panel/settings/settings_raven.vala
+++ b/src/panel/settings/settings_raven.vala
@@ -21,7 +21,7 @@ namespace Budgie {
 		private Gtk.Switch? show_mic_input_widget;
 		private Gtk.Switch? show_mpris_widget;
 		private Gtk.Switch? show_powerstrip;
-		private GLib.Settings raven_settings;
+		private Settings raven_settings;
 
 		public RavenPage() {
 			Object(group: SETTINGS_GROUP_APPEARANCE,
@@ -75,7 +75,7 @@ namespace Budgie {
 				_("Shows or hides the Power Strip in the bottom of Raven.")
 			));
 
-			raven_settings = new GLib.Settings("com.solus-project.budgie-raven");
+			raven_settings = new Settings("com.solus-project.budgie-raven");
 			raven_settings.bind("allow-volume-overdrive", allow_volume_overdrive, "active", SettingsBindFlags.DEFAULT);
 			raven_settings.bind("enable-week-numbers", enable_week_numbers, "active", SettingsBindFlags.DEFAULT);
 			raven_settings.bind("show-calendar-widget", show_calendar_widget, "active", SettingsBindFlags.DEFAULT);

--- a/src/panel/settings/settings_style.vala
+++ b/src/panel/settings/settings_style.vala
@@ -21,8 +21,8 @@ namespace Budgie {
 		private Gtk.Switch? switch_dark;
 		private Gtk.Switch? switch_builtin;
 		private Gtk.Switch? switch_animations;
-		private GLib.Settings ui_settings;
-		private GLib.Settings budgie_settings;
+		private Settings ui_settings;
+		private Settings budgie_settings;
 		private SettingsRow? builtin_row;
 		private ThemeScanner? theme_scanner;
 
@@ -34,8 +34,8 @@ namespace Budgie {
 				icon_name: "preferences-desktop-theme"
 			);
 
-			budgie_settings = new GLib.Settings("com.solus-project.budgie-panel");
-			ui_settings = new GLib.Settings("org.gnome.desktop.interface");
+			budgie_settings = new Settings("com.solus-project.budgie-panel");
+			ui_settings = new Settings("org.gnome.desktop.interface");
 
 			var group = new Gtk.SizeGroup(Gtk.SizeGroupMode.HORIZONTAL);
 			var grid = new SettingsGrid();
@@ -127,7 +127,7 @@ namespace Budgie {
 			ui_settings.bind("enable-animations", switch_animations, "active", SettingsBindFlags.DEFAULT);
 			this.theme_scanner = new ThemeScanner();
 
-			Idle.add(()=> {
+			Idle.add(() => {
 				this.load_themes();
 				return false;
 			});
@@ -135,7 +135,7 @@ namespace Budgie {
 
 		public void load_themes() {
 			/* Scan the themes */
-			this.theme_scanner.scan_themes.begin(()=> {
+			this.theme_scanner.scan_themes.begin(() => {
 				/* Gtk themes */ {
 					Gtk.TreeIter iter;
 					var model = new Gtk.ListStore(1, typeof(string));

--- a/src/panel/settings/settings_wm.vala
+++ b/src/panel/settings/settings_wm.vala
@@ -14,7 +14,7 @@ namespace Budgie {
 	* WindowsPage allows users to control window manager settings
 	*/
 	public class WindowsPage : Budgie.SettingsPage {
-		private GLib.Settings budgie_wm_settings;
+		private Settings budgie_wm_settings;
 		private Gtk.Switch center_windows;
 		private Gtk.Switch disable_night_light;
 		private Gtk.ComboBox combo_layouts;
@@ -99,9 +99,9 @@ namespace Budgie {
 			combo_layouts.set_id_column(0);
 
 			/* Hook up settings */
-			budgie_wm_settings = new GLib.Settings("com.solus-project.budgie-wm");
-			budgie_wm_settings.bind("attach-modal-dialogs", switch_dialogs,	 "active", SettingsBindFlags.DEFAULT);
-			budgie_wm_settings.bind("button-style", combo_layouts,	"active-id", SettingsBindFlags.DEFAULT);
+			budgie_wm_settings = new Settings("com.solus-project.budgie-wm");
+			budgie_wm_settings.bind("attach-modal-dialogs", switch_dialogs, "active", SettingsBindFlags.DEFAULT);
+			budgie_wm_settings.bind("button-style", combo_layouts, "active-id", SettingsBindFlags.DEFAULT);
 			budgie_wm_settings.bind("center-windows", center_windows, "active", SettingsBindFlags.DEFAULT);
 			budgie_wm_settings.bind("disable-night-light-on-fullscreen", disable_night_light, "active", SettingsBindFlags.DEFAULT);
 			budgie_wm_settings.bind("edge-tiling", switch_tiling,  "active", SettingsBindFlags.DEFAULT);

--- a/src/panel/settings/themes.vala
+++ b/src/panel/settings/themes.vala
@@ -1,8 +1,8 @@
 /*
  * This file is part of budgie-desktop
- * 
+ *
  * Copyright © 2015-2019 Budgie Desktop Developers
- * 
+ *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
@@ -37,7 +37,7 @@ class ThemeInfo : GLib.Object {
 	}
 
 	public bool contains_path(string path) {
-		unowned List<string>? g = paths.find_custom(path, GLib.strcmp);
+		unowned List<string>? g = paths.find_custom(path, strcmp);
 		return g != null;
 	}
 }

--- a/src/panel/uuid.vala
+++ b/src/panel/uuid.vala
@@ -11,13 +11,13 @@
 
 namespace LibUUID {
 	public enum UUIDFlags {
-		LOWER_CASE		= 1 << 0,
-		UPPER_CASE		= 1 << 1,
-		DEFAULT_CASE	= 1 << 2,
-		RANDOM_TYPE		= 1 << 3,
-		DEFAULT_TYPE	= 1 << 4,
-		TIME_TYPE		= 1 << 5,
-		TIME_SAFE_TYPE	= 1 << 6
+		LOWER_CASE = 1 << 0,
+		UPPER_CASE = 1 << 1,
+		DEFAULT_CASE = 1 << 2,
+		RANDOM_TYPE = 1 << 3,
+		DEFAULT_TYPE = 1 << 4,
+		TIME_TYPE = 1 << 5,
+		TIME_SAFE_TYPE = 1 << 6
 	}
 
 	public static string @new(LibUUID.UUIDFlags flags) {

--- a/src/polkit/polkitdialog.vala
+++ b/src/polkit/polkitdialog.vala
@@ -10,7 +10,7 @@
  */
 
 namespace Budgie {
-	[GtkTemplate (ui = "/com/solus-project/budgie/polkit/dialog.ui")]
+	[GtkTemplate (ui="/com/solus-project/budgie/polkit/dialog.ui")]
 	public class AgentDialog : Gtk.Window {
 		[GtkChild]
 		private Gtk.Entry? entry_auth;
@@ -66,12 +66,12 @@ namespace Budgie {
 		}
 
 		/* Manipulate Vala's pointer logic to prevent a copy */
-		public unowned GLib.Cancellable? cancellable { public set ; public get; }
+		public unowned Cancellable? cancellable { public set ; public get; }
 
 		public string cookie { public get; public set; }
 
 		/* Save manually setting all this crap via some nice properties */
-		public AgentDialog(string action_id, string message, string icon_name, string cookie, GLib.Cancellable? cancellable) {
+		public AgentDialog(string action_id, string message, string icon_name, string cookie, Cancellable? cancellable) {
 			Object(action_id: action_id, message: message, auth_icon_name: icon_name, cookie: cookie, cancellable: cancellable);
 
 			set_keep_above(true);
@@ -263,14 +263,14 @@ namespace Budgie {
 		/* Theme management */
 		private Budgie.ThemeManager theme_manager;
 
-		public signal void stopagent ();
+		public signal void stopagent();
 
 		public override async bool initiate_authentication(
 			string action_id, string message, string icon_name,
-			Polkit.Details details, string cookie, GLib.List<Polkit.Identity?>? identities, GLib.Cancellable cancellable
+			Polkit.Details details, string cookie, List<Polkit.Identity?>? identities, Cancellable cancellable
 		) throws Polkit.Error {
 			var dialog = new AgentDialog(action_id, message, "dialog-password-symbolic", cookie, cancellable);
-			dialog.done.connect(()=> {
+			dialog.done.connect(() => {
 				initiate_authentication.callback();
 			});
 
@@ -296,7 +296,7 @@ namespace Budgie {
 		public Agent() {
 			theme_manager = new Budgie.ThemeManager();
 
-			register_with_session.begin((o,res)=> {
+			register_with_session.begin((o, res) => {
 				bool success = register_with_session.end(res);
 				if (!success) {
 					message("Failed to register with Session manager");
@@ -311,13 +311,13 @@ namespace Budgie {
 				return false;
 			}
 
-			sclient.QueryEndSession.connect(()=> {
+			sclient.QueryEndSession.connect(() => {
 				end_session(false);
 			});
-			sclient.EndSession.connect(()=> {
+			sclient.EndSession.connect(() => {
 				end_session(false);
 			});
-			sclient.Stop.connect(()=> {
+			sclient.Stop.connect(() => {
 				end_session(true);
 			});
 			return true;

--- a/src/raven/app_sound_control.vala
+++ b/src/raven/app_sound_control.vala
@@ -1,8 +1,8 @@
 /*
  * This file is part of budgie-desktop
- * 
+ *
  * Copyright © 2015-2019 Budgie Desktop Developers
- * 
+ *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
@@ -82,7 +82,7 @@ namespace Budgie {
 			}
 
 			if (usable_icon_name != "applications-multimedia") { // Successfully got an icon from a valid app
-				app_name = app_name.substring(0,1).ascii_up() + app_name.substring(1); // Titalize the app name. Not doing this for non-compliant icons means apps like mocp don't get wrongly titalized.
+				app_name = app_name.substring(0, 1).ascii_up() + app_name.substring(1); // Titalize the app name. Not doing this for non-compliant icons means apps like mocp don't get wrongly titalized.
 			}
 
 			/**

--- a/src/raven/calendar.vala
+++ b/src/raven/calendar.vala
@@ -19,7 +19,7 @@ public class CalendarWidget : RavenWidget {
 
 	private const string date_format = "%e %b %Y";
 
-	public CalendarWidget(GLib.Settings c_settings) {
+	public CalendarWidget(Settings c_settings) {
 		Object(orientation: Gtk.Orientation.VERTICAL);
 		this.settings = c_settings;
 
@@ -37,9 +37,9 @@ public class CalendarWidget : RavenWidget {
 		ebox.add(cal);
 		expander.add(ebox);
 
-		Timeout.add_seconds_full(GLib.Priority.LOW, 30, this.update_date);
+		Timeout.add_seconds_full(Priority.LOW, 30, this.update_date);
 
-		cal.month_changed.connect(()=> {
+		cal.month_changed.connect(() => {
 			update_date();
 		});
 
@@ -63,7 +63,7 @@ public class CalendarWidget : RavenWidget {
 		if (this.settings != null) {
 			try {
 				show = this.settings.get_boolean(ENABLE_WEEK_NUM);
-			} catch (GLib.Error e) {
+			} catch (Error e) {
 				warning("Failed to get value for %s: ", ENABLE_WEEK_NUM);
 			}
 		}

--- a/src/raven/headerwidget.vala
+++ b/src/raven/headerwidget.vala
@@ -1,8 +1,8 @@
 /*
  * This file is part of budgie-desktop
- * 
+ *
  * Copyright © 2015-2019 Budgie Desktop Developers
- * 
+ *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
@@ -166,7 +166,7 @@ namespace Budgie {
 			close_button.get_child().show();
 			header_box.pack_start(close_button, false, false, 0);
 
-			close_button.clicked.connect(()=> {
+			close_button.clicked.connect(() => {
 				this.closed();
 			});
 
@@ -213,16 +213,16 @@ namespace Budgie {
 			pack_start(content, false, false, 0);
 
 			this.header.bind_property("expanded", this, "expanded");
-			content.notify["child-revealed"].connect_after(()=> {
+			content.notify["child-revealed"].connect_after(() => {
 				this.get_toplevel().queue_draw();
 				this.track_animations = false;
 			});
 
-			content.notify["reveal-child"].connect(()=> {
+			content.notify["reveal-child"].connect(() => {
 				this.track_animations = true;
 			});
 
-			content.map.connect_after(()=> {
+			content.map.connect_after(() => {
 				var clock = content.get_frame_clock();
 				clock.after_paint.connect(this.after_paint);
 			});

--- a/src/raven/main_view.vala
+++ b/src/raven/main_view.vala
@@ -31,7 +31,7 @@ namespace Budgie {
 
 		public MainView() {
 			Object(orientation: Gtk.Orientation.VERTICAL, spacing: 0);
-			raven_settings = new GLib.Settings("com.solus-project.budgie-raven");
+			raven_settings = new Settings("com.solus-project.budgie-raven");
 			raven_settings.changed.connect(this.on_raven_settings_changed);
 
 			var header = new Gtk.Box(Gtk.Orientation.HORIZONTAL, 0);

--- a/src/raven/mpris/MprisClient.vala
+++ b/src/raven/mpris/MprisClient.vala
@@ -1,8 +1,8 @@
 /*
  * This file is part of budgie-desktop
- * 
+ *
  * Copyright © 2015-2019 Budgie Desktop Developers
- * 
+ *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
@@ -12,7 +12,7 @@
 /**
  * Simple wrapper to ensure a lifetime reference to the encapsulated objects
  */
-public class MprisClient : Object {
+public class MprisClient : GLib.Object {
 	public PlayerIface player { construct set; get; }
 	public DbusPropIface prop { construct set; get; }
 
@@ -25,7 +25,7 @@ public class MprisClient : Object {
  * We need to probe the dbus daemon directly, hence this interface
  */
 [DBus (name="org.freedesktop.DBus")]
-public interface DBusImpl : Object {
+public interface DBusImpl : GLib.Object {
 	public abstract async string[] list_names() throws IOError;
 	public signal void name_owner_changed(string name, string old_owner, string new_owner);
 	public signal void name_acquired(string name);
@@ -35,7 +35,7 @@ public interface DBusImpl : Object {
  * Vala dbus property notifications are not working. Manually probe property changes.
  */
 [DBus (name="org.freedesktop.DBus.Properties")]
-public interface DbusPropIface : Object {
+public interface DbusPropIface : GLib.Object {
 	public signal void properties_changed(string iface, HashTable<string,Variant> changed, string[] invalid);
 }
 
@@ -43,7 +43,7 @@ public interface DbusPropIface : Object {
  * Represents the base org.mpris.MediaPlayer2 spec
  */
 [DBus (name="org.mpris.MediaPlayer2")]
-public interface MprisIface : Object {
+public interface MprisIface : GLib.Object {
 	public abstract async void raise() throws DBusError, IOError;
 	public abstract async void quit() throws DBusError, IOError;
 
@@ -94,7 +94,6 @@ public interface PlayerIface : MprisIface {
 	public abstract bool can_pause { get; }
 	public abstract bool can_seek { get; }
 	public abstract bool can_control { get; }
-	
 }
 
 /**

--- a/src/raven/mpris/MprisGui.vala
+++ b/src/raven/mpris/MprisGui.vala
@@ -1,8 +1,8 @@
 /*
  * This file is part of budgie-desktop
- * 
+ *
  * Copyright © 2015-2019 Budgie Desktop Developers
- * 
+ *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
@@ -43,7 +43,7 @@ public class ClientWidget : Gtk.Box {
 	Gtk.Button play_btn;
 	Gtk.Button next_btn;
 	string filename = "";
-	GLib.Cancellable? cancel;
+	Cancellable? cancel;
 
 	int our_width = BACKGROUND_SIZE;
 
@@ -57,7 +57,7 @@ public class ClientWidget : Gtk.Box {
 	public ClientWidget(MprisClient client, int width) {
 		Object(orientation: Gtk.Orientation.VERTICAL, spacing: 0);
 		Gtk.Widget? row = null;
-		cancel = new GLib.Cancellable();
+		cancel = new Cancellable();
 
 		our_width = width;
 
@@ -65,7 +65,7 @@ public class ClientWidget : Gtk.Box {
 
 		/* Set up our header widget */
 		header = new Budgie.HeaderWidget(client.player.identity, "media-playback-pause-symbolic", false);
-		header.closed.connect(()=> {
+		header.closed.connect(() => {
 			if (client.player.can_quit) {
 				client.player.quit.begin((obj, res) => {
 					try {
@@ -129,9 +129,9 @@ public class ClientWidget : Gtk.Box {
 		btn.set_sensitive(false);
 		btn.set_can_focus(false);
 		prev_btn = btn;
-		btn.clicked.connect(()=> {
+		btn.clicked.connect(() => {
 			if (client.player.can_go_previous) {
-				try { 
+				try {
 					client.player.previous.begin();
 				} catch (Error e) {
 					warning("Could not go to previous track: %s", e.message);
@@ -144,7 +144,7 @@ public class ClientWidget : Gtk.Box {
 		btn = new Gtk.Button.from_icon_name("media-playback-start-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
 		play_btn = btn;
 		btn.set_can_focus(false);
-		btn.clicked.connect(()=> {
+		btn.clicked.connect(() => {
 			try {
 				client.player.play_pause.begin();
 			} catch (Error e) {
@@ -158,9 +158,9 @@ public class ClientWidget : Gtk.Box {
 		btn.set_sensitive(false);
 		btn.set_can_focus(false);
 		next_btn = btn;
-		btn.clicked.connect(()=> {
+		btn.clicked.connect(() => {
 			if (client.player.can_go_next) {
-				try { 
+				try {
 					client.player.next.begin();
 				} catch (Error e) {
 					warning("Could not go to next track: %s", e.message);
@@ -179,22 +179,22 @@ public class ClientWidget : Gtk.Box {
 		update_play_status();
 		update_controls();
 
-		client.prop.properties_changed.connect((i,p,inv)=> {
+		client.prop.properties_changed.connect((i, p, inv) => {
 			if (i == "org.mpris.MediaPlayer2.Player") {
 				/* Handle mediaplayer2 iface */
-				p.foreach((k,v)=> {
+				p.foreach((k, v) => {
 					if (k == "Metadata") {
-						Idle.add(()=> {
+						Idle.add(() => {
 							update_from_meta();
 							return false;
 						});
 					} else if (k == "PlaybackStatus") {
-						Idle.add(()=> {
+						Idle.add(() => {
 							update_play_status();
 							return false;
 						});
 					} else if (k == "CanGoNext" || k == "CanGoPrevious") {
-						Idle.add(()=> {
+						Idle.add(() => {
 							update_controls();
 							return false;
 						});
@@ -323,7 +323,7 @@ public class ClientWidget : Gtk.Box {
 
 		try {
 			// open the stream
-			var art_file = GLib.File.new_for_uri(proper_uri);
+			var art_file = File.new_for_uri(proper_uri);
 			// download the art
 			var ins = yield art_file.read_async(Priority.DEFAULT, cancel);
 			Gdk.Pixbuf? pbuf = yield new Gdk.Pixbuf.from_stream_at_scale_async(ins,

--- a/src/raven/mpris/MprisWidget.vala
+++ b/src/raven/mpris/MprisWidget.vala
@@ -1,8 +1,8 @@
 /*
  * This file is part of budgie-desktop
- * 
+ *
  * Copyright © 2015-2019 Budgie Desktop Developers
- * 
+ *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
@@ -17,7 +17,7 @@ public class MprisWidget : RavenWidget {
 	int our_width = 250;
 
 	public MprisWidget() {
-		Object (orientation: Gtk.Orientation.VERTICAL, spacing: 0);
+		Object(orientation: Gtk.Orientation.VERTICAL, spacing: 0);
 
 		ifaces = new HashTable<string,ClientWidget>(str_hash, str_equal);
 
@@ -84,14 +84,14 @@ public class MprisWidget : RavenWidget {
 			return;
 		}
 		if (o == "") {
-			new_iface.begin(n, (o,r) => {
+			new_iface.begin(n, (o, r) => {
 				var iface = new_iface.end(r);
 				if (iface != null) {
 					add_iface(n, iface);
 				}
 			});
 		} else {
-			Idle.add(()=> {
+			Idle.add(() => {
 				destroy_iface(n);
 				return false;
 			});

--- a/src/raven/notification_clone.vala
+++ b/src/raven/notification_clone.vala
@@ -1,8 +1,8 @@
 /*
  * This file is part of budgie-desktop
- * 
+ *
  * Copyright © 2015-2019 Budgie Desktop Developers
- * 
+ *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or

--- a/src/raven/notifications_group.vala
+++ b/src/raven/notifications_group.vala
@@ -15,7 +15,7 @@ namespace Budgie {
 	 */
 	public class NotificationGroup : Gtk.Box {
 		public int? count = 0;
-		private HashTable<uint, NotificationClone>? notifications = null;
+		private HashTable<uint,NotificationClone>? notifications = null;
 		private Gtk.ListBox? list = null;
 		private Gtk.Box? header = null;
 		private Gtk.Image? app_image = null;
@@ -47,7 +47,7 @@ namespace Budgie {
 				app_name = _("Caffeine Mode");
 			}
 
-			notifications = new HashTable<uint, NotificationClone>(direct_hash, direct_equal);
+			notifications = new HashTable<uint,NotificationClone>(direct_hash, direct_equal);
 			list = new Gtk.ListBox();
 			list.can_focus = false; // Disable focus to prevent scroll on click
 			list.focus_on_click = false;

--- a/src/raven/notifications_view.vala
+++ b/src/raven/notifications_view.vala
@@ -1,9 +1,9 @@
 /*
  * This file is part of budgie-desktop
- * 
+ *
  * Copyright © 2015-2019 Budgie Desktop Developers
  * Copyright 2014 Josh Klar <j@iv597.com> (original Budgie work, prior to Budgie 10)
- * 
+ *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
@@ -12,7 +12,7 @@
 
 namespace Budgie {
 	[DBus (name="org.budgie_desktop.Raven")]
-	public interface RavenRemote : Object {
+	public interface RavenRemote : GLib.Object {
 		public signal void ClearAllNotifications();
 	}
 
@@ -34,10 +34,10 @@ namespace Budgie {
 	};
 
 	public enum NotificationCloseReason {
-		EXPIRED = 1,	/** The notification expired. */
-		DISMISSED = 2,	/** The notification was dismissed by the user. */
-		CLOSED = 3,		/** The notification was closed by a call to CloseNotification. */
-		UNDEFINED = 4	/** Undefined/reserved reasons. */
+		EXPIRED = 1, /** The notification expired. */
+		DISMISSED = 2, /** The notification was dismissed by the user. */
+		CLOSED = 3, /** The notification was closed by a call to CloseNotification. */
+		UNDEFINED = 4 /** Undefined/reserved reasons. */
 	}
 
 	public enum NotificationPosition {
@@ -55,7 +55,7 @@ namespace Budgie {
 		/* Explicit copy */
 		string inp2 = "" + inp;
 
-		/* 
+		/*
 		* is it already escaped?
 		*/
 		foreach (string str in ESCAPE_STRINGS) {
@@ -108,11 +108,11 @@ namespace Budgie {
 		}
 	}
 
-	[GtkTemplate (ui = "/com/solus-project/budgie/raven/notification.ui")]
+	[GtkTemplate (ui="/com/solus-project/budgie/raven/notification.ui")]
 	public class NotificationWindow : Gtk.Window {
 		public NotificationsView? owner { public set ; public get; }
 
-		public NotificationWindow(NotificationsView? owner)	 {
+		public NotificationWindow(NotificationsView? owner) {
 			Object(type: Gtk.WindowType.POPUP, type_hint: Gdk.WindowTypeHint.NOTIFICATION, owner: owner);
 			resizable = false;
 			skip_pager_hint = true;
@@ -123,11 +123,11 @@ namespace Budgie {
 			if (vis != null) {
 				this.set_visual(vis);
 			}
-			cancel = new GLib.Cancellable();
+			cancel = new Cancellable();
 
 			set_default_size(NOTIFICATION_SIZE, -1);
 
-			button_release_event.connect(()=> {
+			button_release_event.connect(() => {
 				if (!this.has_default_action) {
 					return Gdk.EVENT_PROPAGATE;
 				}
@@ -208,7 +208,7 @@ namespace Budgie {
 		private uint expire_id = 0;
 		private uint32 timeout = 0;
 
-		private GLib.Cancellable? cancel;
+		private Cancellable? cancel;
 		public string? category = null;
 
 		public bool did_interact = false;
@@ -293,19 +293,19 @@ namespace Budgie {
 			}
 
 			// Read the image fields
-			int width			= img.get_child_value(0).get_int32();
-			int height			= img.get_child_value(1).get_int32();
-			int rowstride		= img.get_child_value(2).get_int32();
-			bool has_alpha		= img.get_child_value(3).get_boolean();
+			int width = img.get_child_value(0).get_int32();
+			int height = img.get_child_value(1).get_int32();
+			int rowstride = img.get_child_value(2).get_int32();
+			bool has_alpha = img.get_child_value(3).get_boolean();
 			int bits_per_sample = img.get_child_value(4).get_int32();
-			int n_channels		= img.get_child_value(5).get_int32();
+			int n_channels = img.get_child_value(5).get_int32();
 			// read the raw data
-			unowned uint8[] raw = (uint8[]) img.get_child_value (6).get_data();
+			unowned uint8[] raw = (uint8[]) img.get_child_value(6).get_data();
 
 			// rebuild and scale the image
-			var pixbuf = new Gdk.Pixbuf.with_unowned_data (raw, Gdk.Colorspace.RGB,
+			var pixbuf = new Gdk.Pixbuf.with_unowned_data(raw, Gdk.Colorspace.RGB,
 				has_alpha, bits_per_sample, width, height, rowstride, null);
-			var scaled_pixbuf = pixbuf.scale_simple(48, 48,	 Gdk.InterpType.BILINEAR);
+			var scaled_pixbuf = pixbuf.scale_simple(48, 48, Gdk.InterpType.BILINEAR);
 
 			// set the image
 			if (scaled_pixbuf != null) {
@@ -322,7 +322,7 @@ namespace Budgie {
 		}
 
 		public async void set_from_notify(uint32 id, string app_name, string app_icon,
-											string summary, string body, HashTable<string, Variant> hints,
+											string summary, string body, HashTable<string,Variant> hints,
 											int32 expire_timeout) {
 			this.id = id;
 			this.hints = hints;
@@ -395,7 +395,7 @@ namespace Budgie {
 			}
 
 			label_title.ellipsize = Pango.EllipsizeMode.END;
-		
+
 			label_body.set_markup(safe_markup_string(body));
 			this.body = body;
 
@@ -489,7 +489,7 @@ namespace Budgie {
 	public const int INITIAL_BUFFER_ZONE = 45;
 	public const int NOTIFICATION_SIZE = 400;
 
-	[DBus (name = "org.freedesktop.Notifications")]
+	[DBus (name="org.freedesktop.Notifications")]
 	public class NotificationsView : Gtk.Box {
 		private const string BUDGIE_PANEL_SCHEMA = "com.solus-project.budgie-panel";
 		private const string NOTIFICATION_SCHEMA = "org.gnome.desktop.notifications.application";
@@ -502,7 +502,7 @@ namespace Budgie {
 		RavenRemote? raven_proxy = null;
 
 		/* Hold onto our Raven proxy ref */
-		void on_raven_get(GLib.Object? o, GLib.AsyncResult? res) {
+		void on_raven_get(Object? o, AsyncResult? res) {
 			try {
 				raven_proxy = Bus.get_proxy.end(res);
 				raven_proxy.ClearAllNotifications.connect(on_clear_all);
@@ -511,7 +511,7 @@ namespace Budgie {
 			}
 		}
 
-		private Settings settings = new GLib.Settings(BUDGIE_PANEL_SCHEMA);
+		private Settings settings = new Settings(BUDGIE_PANEL_SCHEMA);
 
 		private Gtk.Button button_mute;
 		private Gtk.Button clear_notifications_button;
@@ -523,7 +523,7 @@ namespace Budgie {
 		private HeaderWidget? header = null;
 		private bool dnd_enabled = false;
 
-		private GLib.Queue<NotificationWindow?> stack = null;
+		private Queue<NotificationWindow?> stack = null;
 
 		/* Obviously we'll change this.. */
 		private HashTable<uint32,NotificationWindow?> notifications;
@@ -539,7 +539,7 @@ namespace Budgie {
 		}
 
 		private uint32 notif_id = 0;
-		[DBus (visible = false)]
+		[DBus (visible=false)]
 		void on_notification_closed(NotificationWindow? widget, NotificationCloseReason reason) {
 			ulong nid = widget.get_data("npack_id");
 
@@ -621,7 +621,7 @@ namespace Budgie {
 			this.remove_notification(widget.id);
 		}
 
-		[DBus (visible = false)]
+		[DBus (visible=false)]
 		bool remove_notification(uint32 id) {
 			unowned NotificationWindow? widget = notifications.lookup(id);
 			if (widget == null) {
@@ -636,7 +636,7 @@ namespace Budgie {
 			return true;
 		}
 
-		[DBus (visible = false)]
+		[DBus (visible=false)]
 		void update_child_count() {
 			int len = 0;
 
@@ -662,7 +662,7 @@ namespace Budgie {
 
 		public uint32 Notify(string app_name, uint32 replaces_id, string app_icon,
 							string summary, string body, string[] actions,
-							HashTable<string, Variant> hints, int32 expire_timeout) {
+							HashTable<string,Variant> hints, int32 expire_timeout) {
 			++notif_id;
 
 			/**
@@ -722,7 +722,7 @@ namespace Budgie {
 				actions_copy += "%s".printf(action);
 			}
 			/* When we yield vala unrefs everything and we get double frees. GG */
-			pack.set_from_notify.begin(notif_id, app_name, app_icon, summary, body, hints, expire, ()=> {
+			pack.set_from_notify.begin(notif_id, app_name, app_icon, summary, body, hints, expire, () => {
 				pack.set_actions(actions_copy);
 
 				if (configure) {
@@ -731,7 +731,7 @@ namespace Budgie {
 					pack.begin_decay();
 				}
 			});
-			
+
 			return notif_id;
 		}
 
@@ -783,7 +783,7 @@ namespace Budgie {
 						y = ny - tail.get_child().get_allocated_height() - BUFFER_ZONE;
 					} else { // This is the first nofication on the screen
 						x = rect.x + BUFFER_ZONE;
-						
+
 						int height;
 						window.get_size(null, out height); // Get the estimated height of the notification
 						y = (rect.y + rect.height) - height - INITIAL_BUFFER_ZONE;
@@ -836,7 +836,7 @@ namespace Budgie {
 		}
 
 
-		[DBus (visible = false)]
+		[DBus (visible=false)]
 		void clear_all() {
 			performing_clear_all = true;
 
@@ -856,7 +856,7 @@ namespace Budgie {
 			update_child_count();
 		}
 
-		[DBus (visible = false)]
+		[DBus (visible=false)]
 		void do_not_disturb_toggle() {
 			dnd_enabled = !dnd_enabled; // Invert value, so if DND was enabled, set to disabled, otherwise set to enabled
 			button_mute.set_image(!dnd_enabled ? image_notifications_enabled : image_notifications_disabled);
@@ -864,7 +864,7 @@ namespace Budgie {
 		}
 
 
-		[DBus (visible = false)]
+		[DBus (visible=false)]
 		public NotificationsView() {
 			Object(orientation: Gtk.Orientation.VERTICAL, spacing: 0);
 			get_style_context().add_class("raven-notifications-view");
@@ -873,12 +873,12 @@ namespace Budgie {
 			clear_notifications_button.relief = Gtk.ReliefStyle.NONE;
 			clear_notifications_button.no_show_all = true;
 			clear_notifications_button.get_style_context().add_class("clear-all-notifications");
-			
+
 			button_mute = new Gtk.Button();
 			button_mute.set_image(image_notifications_enabled);
 			button_mute.relief = Gtk.ReliefStyle.NONE;
 			button_mute.get_style_context().add_class("do-not-disturb");
-			
+
 			var control_buttons = new Gtk.Box(Gtk.Orientation.HORIZONTAL, 0);
 			control_buttons.pack_start(button_mute, false, false, 0);
 			control_buttons.pack_start(clear_notifications_button, false, false, 0);
@@ -893,7 +893,7 @@ namespace Budgie {
 
 			notifications_list = new HashTable<string,NotificationGroup>(str_hash, str_equal);
 			notifications = new HashTable<uint32,NotificationWindow?>(direct_hash, direct_equal);
-			stack = new GLib.Queue<NotificationWindow?>();
+			stack = new Queue<NotificationWindow?>();
 
 			var scrolledwindow = new Gtk.ScrolledWindow(null, null);
 			scrolledwindow.get_style_context().add_class("raven-background");
@@ -915,7 +915,7 @@ namespace Budgie {
 		}
 
 
-		[DBus (visible = false)]
+		[DBus (visible=false)]
 		void on_bus_acquired(DBusConnection conn) {
 			try {
 				conn.register_object("/org/freedesktop/Notifications", this);
@@ -924,7 +924,7 @@ namespace Budgie {
 			}
 		}
 
-		[DBus (visible = false)]
+		[DBus (visible=false)]
 		void serve_dbus() {
 			Bus.own_name(BusType.SESSION, "org.freedesktop.Notifications",
 				BusNameOwnerFlags.NONE,

--- a/src/raven/powerstrip.vala
+++ b/src/raven/powerstrip.vala
@@ -1,8 +1,8 @@
 /*
  * This file is part of budgie-desktop
- * 
+ *
  * Copyright © 2015-2019 Budgie Desktop Developers
- * 
+ *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
@@ -11,12 +11,12 @@
 
 namespace Budgie {
 	[DBus (name="org.gnome.ScreenSaver")]
-	public interface ScreenSaver : Object {
+	public interface ScreenSaver : GLib.Object {
 		public abstract void lock() throws Error;
 	}
 
 	[DBus (name="org.gnome.SessionManager")]
-	public interface SessionManager : Object {
+	public interface SessionManager : GLib.Object {
 		public abstract async void Logout(uint mode) throws DBusError, IOError;
 	}
 
@@ -41,7 +41,7 @@ namespace Budgie {
 				warning("Unable to contact GNOME Session: %s", e.message);
 			}
 		}
-				
+
 		public PowerStrip(Budgie.Raven? raven) {
 			Gtk.Box? bottom = new Gtk.Box(Gtk.Orientation.HORIZONTAL, 20);
 
@@ -57,7 +57,7 @@ namespace Budgie {
 			get_style_context().add_class("primary-control");
 
 			var btn = new Gtk.Button.from_icon_name("preferences-system-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
-			btn.clicked.connect(()=> {
+			btn.clicked.connect(() => {
 				raven.set_expanded(false);
 				raven.request_settings_ui();
 			});
@@ -66,7 +66,7 @@ namespace Budgie {
 			bottom.pack_start(btn, false, false, 0);
 
 			btn = new Gtk.Button.from_icon_name("system-lock-screen-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
-			btn.clicked.connect(()=> {
+			btn.clicked.connect(() => {
 				raven.set_expanded(false);
 				lock_screen();
 			});
@@ -77,7 +77,7 @@ namespace Budgie {
 
 			btn = new Gtk.Button.from_icon_name("system-log-out-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
 			power_btn = btn;
-			btn.clicked.connect(()=> {
+			btn.clicked.connect(() => {
 				try {
 					raven.set_expanded(false);
 					if (session == null) {
@@ -94,7 +94,7 @@ namespace Budgie {
 
 			lock_btn.no_show_all = true;
 			lock_btn.hide();
-			setup_dbus.begin((obj,res)=> {
+			setup_dbus.begin((obj, res) => {
 				if (saver != null) {
 					lock_btn.no_show_all = false;
 					lock_btn.show_all();
@@ -108,6 +108,6 @@ namespace Budgie {
 			} catch (Error e) {
 				warning("Cannot lock screen: %s", e.message);
 			}
-		}	 
+		}
 	}
 }

--- a/src/raven/raven.vala
+++ b/src/raven/raven.vala
@@ -10,19 +10,19 @@
  */
 
 namespace Budgie {
-	public const string RAVEN_DBUS_NAME		   = "org.budgie_desktop.Raven";
+	public const string RAVEN_DBUS_NAME = "org.budgie_desktop.Raven";
 	public const string RAVEN_DBUS_OBJECT_PATH = "/org/budgie_desktop/Raven";
 
-	[DBus (name = "org.budgie_desktop.Raven")]
+	[DBus (name="org.budgie_desktop.Raven")]
 	public class RavenIface {
 		private Raven? parent = null;
-		[DBus (visible = false)]
+		[DBus (visible=false)]
 		private bool dnd_enabled = false;
 
-		[DBus (visible = false)]
+		[DBus (visible=false)]
 		public uint notifications = 0;
 
-		[DBus (visible = false)]
+		[DBus (visible=false)]
 		public RavenIface(Raven? parent) {
 			this.parent = parent;
 		}
@@ -101,7 +101,7 @@ namespace Budgie {
 			}
 		}
 
-		
+
 		public signal void NotificationsChanged();
 
 		public uint GetNotificationCount() {
@@ -274,7 +274,7 @@ namespace Budgie {
 
 			set_wmclass("raven", "raven");
 
-			settings = new GLib.Settings("com.solus-project.budgie-raven");
+			settings = new Settings("com.solus-project.budgie-raven");
 			settings.changed.connect(this.on_raven_settings_changed);
 
 			Raven._instance = this;
@@ -287,7 +287,7 @@ namespace Budgie {
 			}
 
 			// Response to a scale factor change
-			notify["scale-factor"].connect(()=> {
+			notify["scale-factor"].connect(() => {
 				this.update_geometry(this.old_rect);
 				queue_resize();
 			});
@@ -298,7 +298,7 @@ namespace Budgie {
 			layout = new Gtk.Box(Gtk.Orientation.HORIZONTAL, 0);
 			add(layout);
 
-			enter_notify_event.connect((e)=> {
+			enter_notify_event.connect((e) => {
 				steal_focus();
 				return Gdk.EVENT_PROPAGATE;
 			});
@@ -357,7 +357,7 @@ namespace Budgie {
 					} else { // If we should hide the strip
 						strip.hide();
 					}
-				} catch (GLib.Error e) {
+				} catch (Error e) {
 					strip.show_all(); // Default to showing
 				}
 			}
@@ -375,7 +375,7 @@ namespace Budgie {
 
 		public void setup_dbus() {
 			Bus.own_name(BusType.SESSION, Budgie.RAVEN_DBUS_NAME, BusNameOwnerFlags.ALLOW_REPLACEMENT|BusNameOwnerFlags.REPLACE,
-				on_bus_acquired, ()=> {}, ()=> { warning("Raven could not take dbus!"); });
+				on_bus_acquired, () => {}, () => { warning("Raven could not take dbus!"); });
 		}
 
 		/**
@@ -396,7 +396,7 @@ namespace Budgie {
 
 			this.old_rect = rect;
 
-			move(x,y);
+			move(x, y);
 
 			our_height = height;
 			our_width = width;
@@ -513,7 +513,7 @@ namespace Budgie {
 				}
 			};
 
-			anim.start((a)=> {
+			anim.start((a) => {
 				if ((a.widget as Budgie.Raven).nscale == 0.0) {
 					a.widget.hide();
 				} else {

--- a/src/raven/sound.vala
+++ b/src/raven/sound.vala
@@ -69,7 +69,7 @@ namespace Budgie {
 			derpers = new HashTable<string,string?>(str_hash, str_equal); // Create our GVC Stream app derpers
 			derpers.insert("Vivaldi", "vivaldi"); // Vivaldi
 			derpers.insert("Vivaldi Snapshot", "vivaldi-snapshot"); // Vivaldi Snapshot
-			devices = new HashTable<uint,Gtk.ListBoxRow?>(direct_hash,direct_equal);
+			devices = new HashTable<uint,Gtk.ListBoxRow?>(direct_hash, direct_equal);
 
 			/**
 			 * Shared Construction
@@ -103,7 +103,7 @@ namespace Budgie {
 				devices_list.margin_bottom = 10;
 			} else { // Output
 				settings = new Settings("org.gnome.desktop.sound");
-				apps = new HashTable<uint,Gtk.ListBoxRow?>(direct_hash,direct_equal);
+				apps = new HashTable<uint,Gtk.ListBoxRow?>(direct_hash, direct_equal);
 				budgie_settings = new Settings("com.solus-project.budgie-panel");
 				raven_settings = new Settings("com.solus-project.budgie-raven");
 				gnome_desktop_settings = new Settings("org.gnome.desktop.interface");
@@ -275,7 +275,7 @@ namespace Budgie {
 				primary_notify_id = 0;
 			}
 
-			primary_notify_id = stream.notify.connect((n,p)=> {
+			primary_notify_id = stream.notify.connect((n, p) => {
 				if (p.name == "volume" || p.name == "is-muted") {
 					update_volume();
 				}
@@ -459,7 +459,7 @@ namespace Budgie {
 				if (row != null) { // If this row exists
 					try {
 						apps_listbox.remove(row); // Remove row from listbox
-					} catch (GLib.Error e) {
+					} catch (Error e) {
 						warning("Issue during row destroy: %s", e.message);
 					}
 				}

--- a/src/raven/start_listening.vala
+++ b/src/raven/start_listening.vala
@@ -1,8 +1,8 @@
 /*
  * This file is part of budgie-desktop
- * 
+ *
  * Copyright © 2015-2019 Budgie Desktop Developers
- * 
+ *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or

--- a/src/rundialog/RunDialog.vala
+++ b/src/rundialog/RunDialog.vala
@@ -1,8 +1,8 @@
 /*
  * This file is part of budgie-desktop
- * 
+ *
  * Copyright © 2015-2019 Budgie Desktop Developers
- * 
+ *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
@@ -14,7 +14,7 @@ namespace Budgie {
 	* We need to probe the dbus daemon directly, hence this interface
 	*/
 	[DBus (name="org.freedesktop.DBus")]
-	public interface DBusImpl : Object {
+	public interface DBusImpl : GLib.Object {
 		public abstract async string[] list_names() throws IOError;
 		public signal void name_owner_changed(string name, string old_owner, string new_owner);
 	}
@@ -148,7 +148,7 @@ namespace Budgie {
 			set_border_width(0);
 			set_resizable(false);
 
-			focus_out_event.connect(()=> {
+			focus_out_event.connect(() => {
 				if (!this.focus_quit) {
 					return Gdk.EVENT_STOP;
 				}
@@ -300,7 +300,7 @@ namespace Budgie {
 		*/
 		bool on_key_release(Gdk.EventKey btn) {
 			if (btn.keyval == Gdk.Key.Escape) {
-				Idle.add(()=> {
+				Idle.add(() => {
 					this.application.quit();
 					return false;
 				});
@@ -313,7 +313,7 @@ namespace Budgie {
 		* Handle startup notification, mark it done, quit
 		* We may not get the ID but we'll be told it's launched
 		*/
-		private void on_launched(GLib.AppInfo info, Variant v) {
+		private void on_launched(AppInfo info, Variant v) {
 			Variant? elem;
 
 			var iter = v.iterator();

--- a/src/theme/theme.vapi
+++ b/src/theme/theme.vapi
@@ -1,6 +1,6 @@
 /*
  * This file is part of budgie-desktop
- * 
+ *
  * Copyright © 2015-2017 Budgie Desktop Developers
  *
  * This library is free software; you can redistribute it and/or
@@ -10,12 +10,12 @@
  */
 
 namespace Budgie {
-    [CCode (cheader_filename = "theme.h")]
+    [CCode (cheader_filename="theme.h")]
     public static string form_theme_path(string suffix);
 
-    [CCode (cheader_filename = "theme-manager.h")]
+    [CCode (cheader_filename="theme-manager.h")]
     public class ThemeManager : GLib.Object {
-		[CCode (has_construct_function = false)]
+		[CCode (has_construct_function=false)]
         public ThemeManager();
     }
 }

--- a/src/wm/background.vala
+++ b/src/wm/background.vala
@@ -10,14 +10,14 @@
  */
 
 namespace Budgie {
-	public const string BACKGROUND_SCHEMA	   = "org.gnome.desktop.background";
-	public const string PICTURE_URI_KEY		   = "picture-uri";
-	public const string PRIMARY_COLOR_KEY	   = "primary-color";
-	public const string SECONDARY_COLOR_KEY	   = "secondary-color";
+	public const string BACKGROUND_SCHEMA = "org.gnome.desktop.background";
+	public const string PICTURE_URI_KEY = "picture-uri";
+	public const string PRIMARY_COLOR_KEY = "primary-color";
+	public const string SECONDARY_COLOR_KEY = "secondary-color";
 	public const string COLOR_SHADING_TYPE_KEY = "color-shading-type";
-	public const string BACKGROUND_STYLE_KEY   = "picture-options";
-	public const string GNOME_COLOR_HACK	   = "gnome-control-center/pixmaps/noise-texture-light.png";
-	public const string ACCOUNTS_SCHEMA		   = "org.freedesktop.Accounts";
+	public const string BACKGROUND_STYLE_KEY = "picture-options";
+	public const string GNOME_COLOR_HACK = "gnome-control-center/pixmaps/noise-texture-light.png";
+	public const string ACCOUNTS_SCHEMA = "org.freedesktop.Accounts";
 
 	public class BudgieBackground : Clutter.Actor {
 		private Meta.BackgroundGroup bg_group;
@@ -69,12 +69,12 @@ namespace Budgie {
 			this.set_size(rect.width, rect.height);
 
 			/* If the background keys change, proxy it to libgnomedesktop */
-			settings.change_event.connect(()=> {
+			settings.change_event.connect(() => {
 				gnome_bg.load_from_preferences(this.settings);
 				return false;
 			});
 
-			gnome_bg.changed.connect(()=> {
+			gnome_bg.changed.connect(() => {
 				this.update();
 			});
 			this.set_background_color(Clutter.Color.get_static(Clutter.StaticColor.BLACK));
@@ -117,7 +117,7 @@ namespace Budgie {
 			}
 			images.insert(uri, image);
 			ulong rid = 0;
-			rid = image.loaded.connect(()=> {
+			rid = image.loaded.connect(() => {
 				image.disconnect(rid);
 				Idle.add(load_uri.callback);
 			});
@@ -150,7 +150,7 @@ namespace Budgie {
 		*/
 		void set_accountsservice_user_bg(string background) {
 			DBusConnection bus;
-			Variant		   variant;
+			Variant variant;
 
 			try {
 				bus = Bus.get_sync(BusType.SYSTEM);
@@ -255,7 +255,7 @@ namespace Budgie {
 				var bg_file = File.new_for_uri("file://" + bg_filename);
 				/* Once we know the image is in the image cache, set the background */
 
-				load_uri.begin("file://" + bg_filename, ()=> {
+				load_uri.begin("file://" + bg_filename, () => {
 					background.set_file(bg_file, gnome_bg.get_placement());
 					on_update();
 					set_accountsservice_user_bg(bg_filename);

--- a/src/wm/ibus.vala
+++ b/src/wm/ibus.vala
@@ -44,7 +44,7 @@ namespace Budgie {
 		public void do_init() {
 			/* No ibus-daemon = no ibus manager */
 			if (Environment.find_program_in_path("ibus-daemon") == null) {
-				GLib.message("ibus-daemon unsupported on this system");
+				message("ibus-daemon unsupported on this system");
 				this.ibus_available = false;
 				this.ready();
 				return;
@@ -77,7 +77,7 @@ namespace Budgie {
 			try {
 				new Subprocess.newv(cmdline, SubprocessFlags.NONE);
 			} catch (Error e) {
-				GLib.message("Failed to launch ibus: %s", e.message);
+				message("Failed to launch ibus: %s", e.message);
 				this.ibus_available = false;
 			}
 		}
@@ -89,7 +89,7 @@ namespace Budgie {
 			this.engines = new HashTable<string,weak IBus.EngineDesc>(str_hash, str_equal);
 		}
 
-		private void on_engines_get(GLib.Object? o, GLib.AsyncResult? res) {
+		private void on_engines_get(Object? o, AsyncResult? res) {
 			try {
 				this.enginelist = this.bus.list_engines_async_finish(res);
 				this.reset_ibus();
@@ -98,7 +98,7 @@ namespace Budgie {
 					this.engines[engine.get_name()] = engine;
 				}
 			} catch (Error e) {
-				GLib.message("Failed to get engines: %s", e.message);
+				message("Failed to get engines: %s", e.message);
 				this.reset_ibus();
 				return;
 			}
@@ -149,7 +149,7 @@ namespace Budgie {
 				return;
 			}
 
-			this.bus.set_global_engine_async.begin(name, ENGINE_SET_TIMEOUT, null, ()=> {
+			this.bus.set_global_engine_async.begin(name, ENGINE_SET_TIMEOUT, null, () => {
 				this.kbm.release_keyboard();
 			});
 		}

--- a/src/wm/keyboard.vala
+++ b/src/wm/keyboard.vala
@@ -1,9 +1,9 @@
 /*
  * This file is part of budgie-desktop
- * 
+ *
  * Copyright © 2015-2019 Budgie Desktop Developers
  * Copyright (C) GNOME Shell Developers (Heavy inspiration, logic theft)
- * 
+ *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
@@ -97,7 +97,7 @@ namespace Budgie {
 			on_settings_changed("sources");
 		}
 
-		public delegate void KeyHandlerFunc (Meta.Display display, Meta.Window? window, Clutter.KeyEvent? event, Meta.KeyBinding binding);
+		public delegate void KeyHandlerFunc(Meta.Display display, Meta.Window? window, Clutter.KeyEvent? event, Meta.KeyBinding binding);
 
 		void switch_input_source(Meta.Display display,
 								Meta.Window? window, Clutter.KeyEvent? event,
@@ -241,7 +241,7 @@ namespace Budgie {
 				Gnome.get_input_source_from_locale(DEFAULT_LOCALE, out type, out id);
 			}
 
-			if(xkb.get_layout_info(id, out display_name, out short_name, out xkb_layout, out xkb_variant)) {
+			if (xkb.get_layout_info(id, out display_name, out short_name, out xkb_layout, out xkb_variant)) {
 				try {
 					fallback = new InputSource(this.ibus_manager, id, 0, xkb_layout, xkb_variant, true);
 				} catch (Error e) {

--- a/src/wm/main.vala
+++ b/src/wm/main.vala
@@ -1,8 +1,8 @@
 /*
  * This file is part of budgie-desktop
- * 
+ *
  * Copyright © 2015-2019 Budgie Desktop Developers
- * 
+ *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or

--- a/src/wm/shim.vala
+++ b/src/wm/shim.vala
@@ -18,7 +18,7 @@ namespace Budgie {
 	#endif
 	}
 
-	[DBus (name = "org.gnome.SessionManager.EndSessionDialog")]
+	[DBus (name="org.gnome.SessionManager.EndSessionDialog")]
 	public class SessionHandler : GLib.Object {
 		public signal void ConfirmedLogout();
 		public signal void ConfirmedReboot();
@@ -36,19 +36,19 @@ namespace Budgie {
 		void on_dialog_get(Object? o, AsyncResult? res) {
 			try {
 				proxy = Bus.get_proxy.end(res);
-				proxy.ConfirmedLogout.connect(()=> {
+				proxy.ConfirmedLogout.connect(() => {
 					this.ConfirmedLogout();
 				});
-				proxy.ConfirmedReboot.connect(()=> {
+				proxy.ConfirmedReboot.connect(() => {
 					this.ConfirmedReboot();
 				});
-				proxy.ConfirmedShutdown.connect(()=> {
+				proxy.ConfirmedShutdown.connect(() => {
 					this.ConfirmedShutdown();
 				});
-				proxy.Canceled.connect(()=> {
+				proxy.Canceled.connect(() => {
 					this.Canceled();
 				});
-				proxy.Closed.connect(()=> {
+				proxy.Closed.connect(() => {
 					this.Closed();
 				});
 			} catch (Error e) {
@@ -92,7 +92,7 @@ namespace Budgie {
 	/**
 	* Wrap the EndSessionDialog type inside Budgie itself
 	*/
-	[DBus (name = "org.budgie_desktop.Session.EndSessionDialog")]
+	[DBus (name="org.budgie_desktop.Session.EndSessionDialog")]
 	public interface EndSessionDialog : GLib.Object {
 		public signal void ConfirmedLogout();
 		public signal void ConfirmedReboot();
@@ -108,23 +108,23 @@ namespace Budgie {
 	/**
 	* Expose the BudgieOSD functionality for proxying of the Shell OSD Functionality
 	*/
-	[DBus (name = "org.budgie_desktop.BudgieOSD")]
+	[DBus (name="org.budgie_desktop.BudgieOSD")]
 	public interface BudgieOSD : GLib.Object {
 		/**
 		* Budgie GTK+ On Screen Display
 		*
 		* Valid params:
-		*	icon: string
-		*	label: string
-		*	level: int32
-		*	monitor: int32
+		*   icon: string
+		*   label: string
+		*   level: int32
+		*   monitor: int32
 		*/
 		public abstract async void ShowOSD(HashTable<string,Variant> params) throws Error;
 	}
 
-	[DBus (name = "org.gnome.Shell")]
+	[DBus (name="org.gnome.Shell")]
 	public class ShellShim : GLib.Object {
-		HashTable<string, uint?> grabs;
+		HashTable<string,uint?> grabs;
 		unowned Meta.Display? display;
 
 		private SessionHandler? handler = null;
@@ -132,9 +132,9 @@ namespace Budgie {
 		/* Proxy off the OSD Calls */
 		private BudgieOSD? osd_proxy = null;
 
-		[DBus (visible = false)]
+		[DBus (visible=false)]
 		public ShellShim(Budgie.BudgieWM? wm) {
-			grabs = new HashTable<string, uint?> (str_hash, str_equal);
+			grabs = new HashTable<string,uint?>(str_hash, str_equal);
 
 			display = wm.get_display();
 			display.accelerator_activated.connect(on_accelerator_activated);
@@ -173,24 +173,24 @@ namespace Budgie {
 			osd_proxy = null;
 		}
 
-	private void on_accelerator_activated(uint action, Clutter.InputDevice dev, uint timestamp) {
-			foreach (string accelerator in grabs.get_keys ()) {
+		private void on_accelerator_activated(uint action, Clutter.InputDevice dev, uint timestamp) {
+			foreach (string accelerator in grabs.get_keys()) {
 				if (grabs[accelerator] == action) {
-					var params = new GLib.HashTable<string, Variant> (null, null);
-					params.set ("device-id", new Variant.uint32 (dev.id));
-					params.set ("action-mode", new Variant.uint32 (action));
-					params.set ("device-mode", new Variant.string (dev.get_device_node()));
-					params.set ("timestamp", new Variant.uint32 (timestamp));
-					this.accelerator_activated (action, params);
+					var params = new HashTable<string,Variant>(null, null);
+					params.set("device-id", new Variant.uint32(dev.id));
+					params.set("action-mode", new Variant.uint32(action));
+					params.set("device-mode", new Variant.string(dev.get_device_node()));
+					params.set("timestamp", new Variant.uint32(timestamp));
+					this.accelerator_activated(action, params);
 				}
 			}
 		}
 
-		public uint grab_accelerator (string accelerator, Meta.KeyBindingFlags flags) throws DBusError, IOError {
+		public uint grab_accelerator(string accelerator, Meta.KeyBindingFlags flags) throws DBusError, IOError {
 			uint? action = grabs[accelerator];
 
 			if (action == null) {
-				action = display.grab_accelerator (accelerator, flags);
+				action = display.grab_accelerator(accelerator, flags);
 				if (action > 0) {
 					grabs[accelerator] = action;
 				}
@@ -199,23 +199,23 @@ namespace Budgie {
 			return action;
 		}
 
-		public uint[] grab_accelerators (GsdAccel[] accelerators) throws DBusError, IOError {
+		public uint[] grab_accelerators(GsdAccel[] accelerators) throws DBusError, IOError {
 			uint[] actions = {};
 
 			foreach (unowned GsdAccel? accelerator in accelerators) {
-				actions += grab_accelerator (accelerator.accelerator, accelerator.grab_flags);
+				actions += grab_accelerator(accelerator.accelerator, accelerator.grab_flags);
 			}
 
 			return actions;
 		}
 
-		public bool ungrab_accelerator (uint action) throws DBusError, IOError {
+		public bool ungrab_accelerator(uint action) throws DBusError, IOError {
 			bool ret = false;
 			var keys = grabs.get_keys();
 			foreach (unowned string accelerator in keys) {
 				if (grabs[accelerator] == action) {
-					ret = display.ungrab_accelerator (action);
-					grabs.remove (accelerator);
+					ret = display.ungrab_accelerator(action);
+					grabs.remove(accelerator);
 					break;
 				}
 			}
@@ -232,7 +232,7 @@ namespace Budgie {
 			}
 		}
 
-		[DBus (visible = false)]
+		[DBus (visible=false)]
 		public void serve() {
 			Bus.own_name(BusType.SESSION, "org.gnome.Shell",
 				BusNameOwnerFlags.ALLOW_REPLACEMENT|BusNameOwnerFlags.REPLACE,
@@ -248,12 +248,12 @@ namespace Budgie {
 		}
 
 		public bool UngrabAccelerator(BusName sender, uint action) {
-			return ungrab_accelerator (action);
+			return ungrab_accelerator(action);
 		}
 
 		public bool UngrabAccelerators(BusName sender, uint[] actions) {
 			foreach (uint action in actions) {
-				ungrab_accelerator (action);
+				ungrab_accelerator(action);
 			}
 			return true;
 		}

--- a/src/wm/wm.vala
+++ b/src/wm/wm.vala
@@ -10,30 +10,30 @@
  */
 
 namespace Budgie {
-	public const string MUTTER_EDGE_TILING	 = "edge-tiling";
-	public const string MUTTER_MODAL_ATTACH	 = "attach-modal-dialogs";
+	public const string MUTTER_EDGE_TILING = "edge-tiling";
+	public const string MUTTER_MODAL_ATTACH = "attach-modal-dialogs";
 	public const string MUTTER_BUTTON_LAYOUT = "button-layout";
 	public const string EXPERIMENTAL_DIALOG = "experimental-enable-run-dialog-as-menu";
-	public const string WM_FORCE_UNREDIRECT	 = "force-unredirect";
-	public const string WM_SCHEMA			 = "com.solus-project.budgie-wm";
+	public const string WM_FORCE_UNREDIRECT = "force-unredirect";
+	public const string WM_SCHEMA = "com.solus-project.budgie-wm";
 
 	public const bool CLUTTER_EVENT_PROPAGATE = false;
-	public const bool CLUTTER_EVENT_STOP	  = true;
+	public const bool CLUTTER_EVENT_STOP = true;
 
-	public const string RAVEN_DBUS_NAME		   = "org.budgie_desktop.Raven";
+	public const string RAVEN_DBUS_NAME = "org.budgie_desktop.Raven";
 	public const string RAVEN_DBUS_OBJECT_PATH = "/org/budgie_desktop/Raven";
 
-	public const string PANEL_DBUS_NAME		   = "org.budgie_desktop.Panel";
+	public const string PANEL_DBUS_NAME = "org.budgie_desktop.Panel";
 	public const string PANEL_DBUS_OBJECT_PATH = "/org/budgie_desktop/Panel";
 
-	public const string LOGIND_DBUS_NAME		= "org.freedesktop.login1";
+	public const string LOGIND_DBUS_NAME = "org.freedesktop.login1";
 	public const string LOGIND_DBUS_OBJECT_PATH = "/org/freedesktop/login1";
 
 	/** Menu management */
-	public const string MENU_DBUS_NAME		  = "org.budgie_desktop.MenuManager";
+	public const string MENU_DBUS_NAME = "org.budgie_desktop.MenuManager";
 	public const string MENU_DBUS_OBJECT_PATH = "/org/budgie_desktop/MenuManager";
 
-	public const string SWITCHER_DBUS_NAME		  = "org.budgie_desktop.TabSwitcher";
+	public const string SWITCHER_DBUS_NAME = "org.budgie_desktop.TabSwitcher";
 	public const string SWITCHER_DBUS_OBJECT_PATH = "/org/budgie_desktop/TabSwitcher";
 
 	[Flags]
@@ -44,10 +44,10 @@ namespace Budgie {
 	}
 
 	public enum AnimationState {
-		MAP			= 1 << 0,
-		MINIMIZE	= 1 << 1,
-		UNMINIMIZE	= 1 << 2,
-		DESTROY		= 1 << 3
+		MAP = 1 << 0,
+		MINIMIZE = 1 << 1,
+		UNMINIMIZE = 1 << 2,
+		DESTROY = 1 << 3
 	}
 
 	public class ScreenTilePreview : Clutter.Actor {
@@ -63,7 +63,7 @@ namespace Budgie {
 
 
 	[DBus (name="org.budgie_desktop.Raven")]
-	public interface RavenRemote : Object {
+	public interface RavenRemote : GLib.Object {
 		public abstract bool GetExpanded() throws Error;
 		public abstract async void Toggle() throws Error;
 		public abstract async void ToggleNotificationsView() throws Error;
@@ -72,12 +72,12 @@ namespace Budgie {
 		public abstract async void Dismiss() throws Error;
 	}
 
-	[DBus (name = "org.budgie_desktop.Panel")]
-	public interface PanelRemote : Object {
+	[DBus (name="org.budgie_desktop.Panel")]
+	public interface PanelRemote : GLib.Object {
 		public abstract async void ActivateAction(int flags) throws Error;
 	}
 
-	[DBus (name = "org.freedesktop.login1.Manager")]
+	[DBus (name="org.freedesktop.login1.Manager")]
 	public interface LoginDRemote : GLib.Object {
 		public signal void PrepareForSleep(bool suspending);
 	}
@@ -85,7 +85,7 @@ namespace Budgie {
 	/**
 	* Allows us to invoke desktop menus without directly using GTK+ ourselves
 	*/
-	[DBus (name = "org.budgie_desktop.MenuManager")]
+	[DBus (name="org.budgie_desktop.MenuManager")]
 	public interface MenuManager: GLib.Object {
 		public abstract async void ShowDesktopMenu(uint button, uint32 timestamp) throws Error;
 		public abstract async void ShowWindowMenu(uint32 xid, uint button, uint32 timestamp) throws Error;
@@ -94,7 +94,7 @@ namespace Budgie {
 	/**
 	* Allows us to display the tab switcher without Gtk
 	*/
-	[DBus (name = "org.budgie_desktop.TabSwitcher")]
+	[DBus (name="org.budgie_desktop.TabSwitcher")]
 	public interface Switcher: GLib.Object {
 		public abstract async void PassItem(uint32 xid, uint32 timestamp) throws Error;
 		public abstract async void ShowSwitcher(uint32 curr_xid) throws Error;
@@ -147,7 +147,7 @@ namespace Budgie {
 
 		private bool force_unredirect = false;
 
-		HashTable<Meta.WindowActor?,AnimationState?> state_map;
+		HashTable<Meta.WindowActor?, AnimationState?> state_map;
 		Clutter.Actor? display_group;
 		bool enabled_experimental_run_diag_as_menu = false;
 
@@ -172,7 +172,7 @@ namespace Budgie {
 		}
 
 		/* Hold onto our Raven proxy ref */
-		void on_raven_get(GLib.Object? o, GLib.AsyncResult? res) {
+		void on_raven_get(Object? o, AsyncResult? res) {
 			try {
 				raven_proxy = Bus.get_proxy.end(res);
 			} catch (Error e) {
@@ -181,7 +181,7 @@ namespace Budgie {
 		}
 
 		/* Obtain Panel manager */
-		void on_panel_get(GLib.Object? o, GLib.AsyncResult? res) {
+		void on_panel_get(Object? o, AsyncResult? res) {
 			try {
 				panel_proxy = Bus.get_proxy.end(res);
 			} catch (Error e) {
@@ -200,7 +200,7 @@ namespace Budgie {
 		}
 
 		/* Obtain Menu manager */
-		void on_menu_get(GLib.Object? o, GLib.AsyncResult? res) {
+		void on_menu_get(Object? o, AsyncResult? res) {
 			try {
 				menu_proxy = Bus.get_proxy.end(res);
 			} catch (Error e) {
@@ -219,7 +219,7 @@ namespace Budgie {
 		}
 
 		/* Obtain login manager */
-		void on_logind_get(GLib.Object? o, GLib.AsyncResult? res) {
+		void on_logind_get(Object? o, AsyncResult? res) {
 			try {
 				logind_proxy = Bus.get_proxy.end(res);
 				if (logind_proxy == null) {
@@ -251,7 +251,7 @@ namespace Budgie {
 			switcher_proxy = null;
 		}
 
-		void on_switcher_get(GLib.Object? o, GLib.AsyncResult? res) {
+		void on_switcher_get(Object? o, AsyncResult? res) {
 			try {
 				switcher_proxy = Bus.get_proxy.end(res);
 			} catch (Error e) {
@@ -260,7 +260,7 @@ namespace Budgie {
 		}
 
 		void has_switcher() {
-			if(switcher_proxy == null) {
+			if (switcher_proxy == null) {
 				Bus.get_proxy.begin<Switcher>(BusType.SESSION, SWITCHER_DBUS_NAME, SWITCHER_DBUS_OBJECT_PATH, 0, null, on_switcher_get);
 			}
 		}
@@ -270,9 +270,9 @@ namespace Budgie {
 			try {
 				string cmd=this.settings.get_string("full-screenshot-cmd");
 				if (cmd != "")
-					Process.spawn_command_line_async (cmd);
+					Process.spawn_command_line_async(cmd);
 			} catch (SpawnError e) {
-				print ("Error: %s\n", e.message);
+				print("Error: %s\n", e.message);
 			}
 		}
 
@@ -281,9 +281,9 @@ namespace Budgie {
 			try {
 				string cmd=this.settings.get_string("take-region-screenshot-cmd");
 				if (cmd != "")
-					Process.spawn_command_line_async (cmd);
+					Process.spawn_command_line_async(cmd);
 			} catch (SpawnError e) {
-				print ("Error: %s\n", e.message);
+				print("Error: %s\n", e.message);
 			}
 		}
 
@@ -292,9 +292,9 @@ namespace Budgie {
 			try {
 				string cmd=this.settings.get_string("take-window-screenshot-cmd");
 				if (cmd != "")
-					Process.spawn_command_line_async (cmd);
+					Process.spawn_command_line_async(cmd);
 			} catch (SpawnError e) {
-				print ("Error: %s\n", e.message);
+				print("Error: %s\n", e.message);
 			}
 		}
 
@@ -369,7 +369,7 @@ namespace Budgie {
 					message("Failed to launch Budgie Run Dialog: %s", e.message);
 				}
 			} else {
-				Idle.add(()=> {
+				Idle.add(() => {
 					try {
 						panel_proxy.ActivateAction.begin((int) PanelAction.MENU);
 					} catch (Error e) {
@@ -394,7 +394,7 @@ namespace Budgie {
 			} catch (Error e) {}
 		}
 
-		void on_dialog_closed(GLib.Pid pid, int status) {
+		void on_dialog_closed(Pid pid, int status) {
 			bool ok = false;
 			try {
 				ok = Process.check_exit_status(status);
@@ -404,7 +404,7 @@ namespace Budgie {
 		}
 
 		public override void confirm_display_change() {
-			GLib.Pid pid = Meta.Util.show_dialog("--question",
+			Pid pid = Meta.Util.show_dialog("--question",
 							"Does the display look OK?",
 							"20",
 							null,
@@ -439,7 +439,7 @@ namespace Budgie {
 			display_group = Meta.Compositor.get_window_group_for_display(display);
 			var stage = Meta.Compositor.get_stage_for_display(display);
 
-			state_map = new HashTable<Meta.WindowActor?,AnimationState?>(GLib.direct_hash, GLib.direct_equal);
+			state_map = new HashTable<Meta.WindowActor?, AnimationState?>(direct_hash, direct_equal);
 
 			iface_settings = new Settings("org.gnome.desktop.interface");
 			iface_settings.bind("enable-animations", this, "use-animations", SettingsBindFlags.DEFAULT);
@@ -564,7 +564,7 @@ namespace Budgie {
 			if (menu_proxy == null) {
 				return;
 			}
-			Timeout.add(100, ()=> {
+			Timeout.add(100, () => {
 				uint32 xid = (uint32)window.get_xwindow();
 				try {
 					menu_proxy.ShowWindowMenu.begin(xid, 3, 0);
@@ -623,13 +623,13 @@ namespace Budgie {
 			}
 		}
 
-		const int MAP_TIMEOUT  = 100;
+		const int MAP_TIMEOUT = 100;
 		const int MENU_MAP_TIMEOUT = 120;
-		const float MAP_SCALE  = 0.94f;
+		const float MAP_SCALE = 0.94f;
 		const float MENU_MAP_SCALE_X = 0.98f;
 		const float MENU_MAP_SCALE_Y = 0.95f;
-		const float NOTIFICATION_MAP_SCALE_X  = 0.5f;
-		const float NOTIFICATION_MAP_SCALE_Y  = 0.8f;
+		const float NOTIFICATION_MAP_SCALE_X = 0.5f;
+		const float NOTIFICATION_MAP_SCALE_Y = 0.8f;
 		const int FADE_TIMEOUT = 145;
 
 		void finalize_animations(Meta.WindowActor? actor) {
@@ -866,7 +866,7 @@ namespace Budgie {
 			finalize_animations(actor as Meta.WindowActor);
 		}
 
-		const int DESTROY_TIMEOUT  = 120;
+		const int DESTROY_TIMEOUT = 120;
 		const double DESTROY_SCALE = 0.88;
 
 		public override void destroy(Meta.WindowActor actor) {
@@ -1126,8 +1126,8 @@ namespace Budgie {
 		}
 
 		/* Return sorted list of user open tabs */
-		private List<weak Meta.Window> get_current_tabs(Meta.Display display, 
-						Meta.Workspace workspace, 
+		private List<weak Meta.Window> get_current_tabs(Meta.Display display,
+						Meta.Workspace workspace,
 						bool getTabsForAllWindows) {
 			List<weak Meta.Window> tabs;
 			CompareFunc<weak Meta.Window> cm = Budgie.BudgieWM.tab_sort_reverse;
@@ -1135,7 +1135,7 @@ namespace Budgie {
 			if (getTabsForAllWindows) {
 				tabs = display.get_tab_list(Meta.TabList.NORMAL, null);
 			} else {
-				//	Return only tabs for the current workspace
+				// Return only tabs for the current workspace
 				tabs = display.get_tab_list(Meta.TabList.NORMAL, workspace);
 			}
 
@@ -1307,16 +1307,16 @@ namespace Budgie {
 	* This part of the equation is inspired by wingpanel, which uses our
 	* popover manager.
 	*/
-	[DBus (name = "org.budgie_desktop.BudgieWM")]
+	[DBus (name="org.budgie_desktop.BudgieWM")]
 	public class BudgieWMDBUS : GLib.Object {
 		unowned Budgie.BudgieWM? wm;
 
-		[DBus (visible = false)]
+		[DBus (visible=false)]
 		public BudgieWMDBUS(Budgie.BudgieWM? wm) {
 			this.wm = wm;
 		}
 
-		[DBus (visible = false)]
+		[DBus (visible=false)]
 		void on_bus_acquired(DBusConnection conn) {
 			try {
 				conn.register_object("/org/budgie_desktop/BudgieWM", this);
@@ -1325,7 +1325,7 @@ namespace Budgie {
 			}
 		}
 
-		[DBus (visible = false)]
+		[DBus (visible=false)]
 		public void serve() {
 			Bus.own_name(BusType.SESSION, "org.budgie_desktop.BudgieWM",
 				BusNameOwnerFlags.ALLOW_REPLACEMENT|BusNameOwnerFlags.REPLACE,

--- a/update_format.sh
+++ b/update_format.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
+
 # Ensure we're formatted everywhere.
-clang-format -i $(find src -name '*.[ch]' -not -path '*/gvc/*' -not -path '*/natray/*')
+clang-format -i $(find src -name '*.[ch]' -not -path '*/gvc/*')
 
 # Check we have no typos.
 which misspell 2>/dev/null >/dev/null
 if [[ $? -eq 0 ]]; then
-    misspell -error `find src -name '*.[ch]' -not -path '*/gvc/*' -not -path '*/natray/*'`
-    misspell -error `find src -name '*.vala' -not -path '*/gvc/*' -not -path '*/natray/*'`
+    misspell -error `find src -name '*.[ch]' -not -path '*/gvc/*'`
+    misspell -error `find src -name '*.vala' -not -path '*/gvc/*'`
 fi


### PR DESCRIPTION
## Description
Meant to include this in #2024, but you merged it too quickly! :stuck_out_tongue: 

Cleans up a few things in Vala and VAPI files:
- Remove trailing whitespace on lines
- Replace non-indentation tabs with spaces and remove excess use of whitespace
- Make lambda, argument, parameter, and statement whitespace way more consistent
- Miscellaneous modifications for consistency
- Remove the `GLib.Declaration` prefix in cases where it isn't necessary

I used pattern matching for most of this, so I went through every single changed line to ensure that no side effects were produced. I did find some, specifically string and comment spacing, but all of those have been fixed.

Additionally, added a `.editorconfig` file to the root, and included settings compliant with the new format.

### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
