### PR TITLE
TabSwitcher #1971 adds Ctrl as possible binding for Alt-Tab switching

### DIFF
--- a/src/daemon/tabswitcher.vala
+++ b/src/daemon/tabswitcher.vala
@@ -306,7 +306,7 @@ namespace Budgie {
 			mod_timeout = 0;
 			Gdk.ModifierType modifier;
 			Gdk.Display.get_default().get_default_seat().get_pointer().get_state(Gdk.get_default_root_window(), null, out modifier);
-			if ((modifier & Gdk.ModifierType.MOD1_MASK) == 0 && (modifier & Gdk.ModifierType.MOD4_MASK) == 0) {
+			if ((modifier & Gdk.ModifierType.MOD1_MASK) == 0 && (modifier & Gdk.ModifierType.MOD4_MASK) == 0 && (modifier & Gdk.ModifierType.CONTROL_MASK) == 0) {
 				switcher_window.hide();
 				return false;
 			}


### PR DESCRIPTION
## Description
**Update**
Resolved merge conflict issues 8/27/2020.

If there are any questions then please let me know. I'd like to get this included so my [Kinto.sh](https://github.com/rbreaves/kinto) project no longer needs to swap out the budgie-daemon for reasons that relate to my key remapping efforts.

Original PR here, but that PR and the repo it was from has been deleted. Had difficulties figuring out how to reconcile a detached head state between the two repos and their branches initially.
https://github.com/solus-project/budgie-desktop/pull/2006

-------------------------

Reverted back to original author's type of implementation in case of other unknown held modifier keys, but have added Ctrl as an option for Alt-Tab App/Window switching. This resolves the incompatibility with Kinto/xkeysnail and possibly other key remappers without the possibility of breaking anything.

Reference info
https://valadoc.org/gdk-3.0/Gdk.ModifierType.html

### Submitter Checklist

- [ ] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
