### PR TITLE
Fix build with vala 0.49

### DIFF
--- a/src/appsys/AppSystem.vala
+++ b/src/appsys/AppSystem.vala
@@ -66,7 +66,7 @@ namespace Budgie {
 		}
 
 		private void signal_received(GLib.DBusConnection connection,
-									string sender,
+									string? sender,
 									string object_path,
 									string interface_name,
 									string signal_name,


### PR DESCRIPTION
## Description
Fixes building budgie-desktop with vala 0.49
close #2028 


### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
