### PR TITLE
Make xdg config directory configurable

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -110,6 +110,15 @@ if with_stateless == true
     warning('Only use stateless option with a supported OS like Solus')
 endif
 
+xdg_appdir = get_option('xdg-appdir')
+if xdg_appdir == ''
+    if with_stateless == true
+        xdg_appdir = join_paths(datadir, 'xdg', 'autostart')
+    else
+        xdg_appdir = join_paths(get_option('sysconfdir'), 'xdg', 'autostart')
+    endif
+endif
+
 # GVC rpath. it's evil, but gvc will bomb out glib2 due to static linking weirdness now,
 # so we have to use a shared library to prevent multiple registration of the same types..
 rpath_libdir = join_paths(libdir, meson.project_name())
@@ -163,6 +172,7 @@ report = [
     '    libdir:                                 @0@'.format(libdir),
     '    module library directory:               @0@'.format(plugin_libdir),
     '    module data directory:                  @0@'.format(plugin_datadir),
+    '    xdg config directory:                   @0@'.format(xdg_appdir),
     '',
     '    Extra options:',
     '    ==============',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -2,3 +2,4 @@ option('with-stateless', type: 'boolean', value: false, description: 'Enable sta
 option('with-polkit', type: 'boolean', value: true, description: 'Enable PolKit support')
 option('with-gtk-doc', type: 'boolean', value: true, description: 'Build gtk-doc documentation')
 option('with-desktop-icons', type: 'combo', choices: ['nautilus', 'none'], value: 'nautilus', description: 'Desktop icon handling')
+option('xdg-appdir', type: 'string', description: 'XDG autostart path')

--- a/src/session/meson.build
+++ b/src/session/meson.build
@@ -111,12 +111,6 @@ custom_target('desktop-file-xsession',
     install_dir : join_paths(datadir, 'xsessions'),
 )
 
-# Solus only allows stateless XDG (/usr/share/xdg/autostart) in packaging
-if with_stateless == true
-    xdg_appdir = join_paths(datadir, 'xdg', 'autostart')
-else
-    xdg_appdir = join_paths(get_option('sysconfdir'), 'xdg', 'autostart')
-endif
 
 # Merge + install nm-applet
 custom_target('desktop-file-nm-applet',


### PR DESCRIPTION
## Description
openSUSE will be using /usr/etc/xdg/autostart for its stateless XDG path, so make it configurable so I don't have to patch it. 


### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
  * [Build log](https://build.opensuse.org/build/home:gmbr3:Solus:git/openSUSE_Tumbleweed/i586/budgie-desktop/_log)
