### PR TITLE
Clean up carbontray source and add hint error check

### DIFF
--- a/src/applets/tray/carbontray/child.c
+++ b/src/applets/tray/carbontray/child.c
@@ -20,9 +20,8 @@
 
 static void carbon_child_init(CarbonChild*);
 static void carbon_child_realize(GtkWidget*);
-static void carbon_child_get_preferred_width(GtkWidget*, int*, int*);
-static void carbon_child_get_preferred_height(GtkWidget*, int*, int*);
-static void set_wmclass(CarbonChild*, Display*);
+static void carbon_child_get_preferred_size(GtkWidget*, int*, int*);
+static bool set_wmclass(CarbonChild*, Display*);
 
 
 
@@ -68,24 +67,29 @@ CarbonChild* carbon_child_new(int size, GdkScreen* screen, Window iconWindow) {
 		return NULL;
 
 	CarbonChild* self = g_object_new(CARBON_TYPE_CHILD, NULL);
-	self->preferredWidth = size;
-	self->preferredHeight = size;
+	self->preferredSize = size;
 	self->iconWindow = iconWindow;
 	self->isComposited = FALSE;
 	gtk_widget_set_visual(GTK_WIDGET(self), visual);
 
-	/* check if there is an alpha channel in the visual */
-	int red_prec, green_prec, blue_prec;
-	gdk_visual_get_red_pixel_details(visual, NULL, NULL, &red_prec);
-	gdk_visual_get_green_pixel_details(visual, NULL, NULL, &green_prec);
-	gdk_visual_get_blue_pixel_details(visual, NULL, NULL, &blue_prec);
+	int eventBaseReturn, errorBaseReturn; // unused, we only need to know if composite is supported at all
+	bool supportsComposite = XCompositeQueryExtension(xdisplay, &eventBaseReturn, &errorBaseReturn);
 
-	bool supportsComposite = gdk_display_supports_composite(display);
-	if (red_prec + blue_prec + green_prec < gdk_visual_get_depth(visual) && supportsComposite)
-		self->isComposited = TRUE;
+	if (supportsComposite) {
+		// check if there is an alpha channel in the visual. if there is, we can composite it
+		int red_prec, green_prec, blue_prec;
+		gdk_visual_get_red_pixel_details(visual, NULL, NULL, &red_prec);
+		gdk_visual_get_green_pixel_details(visual, NULL, NULL, &green_prec);
+		gdk_visual_get_blue_pixel_details(visual, NULL, NULL, &blue_prec);
+
+		if (red_prec + blue_prec + green_prec < gdk_visual_get_depth(visual))
+			self->isComposited = TRUE;
+	}
 
 	self->wmclass = NULL;
-	set_wmclass(self, xdisplay);
+	if (!set_wmclass(self, xdisplay))
+		// the icon window turned sour while we were getting alpha details. ignore the child
+		return NULL;
 
 	return self;
 }
@@ -95,12 +99,12 @@ void carbon_child_draw_on_tray(CarbonChild* self, GtkWidget* parent, cairo_t* cr
 	g_return_if_fail(parent != NULL);
 	g_return_if_fail(cr != NULL);
 
-	GtkAllocation allocation = {0};
+	GtkAllocation allocation;
 	gtk_widget_get_allocation(GTK_WIDGET(self), &allocation);
 
-	if (!gtk_widget_get_has_window(GTK_WIDGET(parent))) {
-		GtkAllocation parentAllocation = {0};
-		gtk_widget_get_allocation(GTK_WIDGET(parent), &parentAllocation);
+	if (!gtk_widget_get_has_window(parent)) {
+		GtkAllocation parentAllocation;
+		gtk_widget_get_allocation(parent, &parentAllocation);
 
 		allocation.x = allocation.x - parentAllocation.x;
 		allocation.y = allocation.y - parentAllocation.y;
@@ -120,17 +124,14 @@ void carbon_child_draw_on_tray(CarbonChild* self, GtkWidget* parent, cairo_t* cr
 
 static void carbon_child_init(CarbonChild* self) {
 	GtkWidget* widget = GTK_WIDGET(self);
-
 	gtk_widget_set_halign(widget, GTK_ALIGN_CENTER);
 	gtk_widget_set_valign(widget, GTK_ALIGN_CENTER);
-	gtk_widget_set_hexpand(widget, FALSE);
-	gtk_widget_set_vexpand(widget, FALSE);
 }
 
 static void carbon_child_realize(GtkWidget* widget) {
 	CarbonChild* self = CARBON_CHILD(widget);
 
-	gtk_widget_set_size_request(widget, self->preferredWidth, self->preferredHeight);
+	gtk_widget_set_size_request(widget, self->preferredSize, self->preferredSize);
 	GTK_WIDGET_CLASS(carbon_child_parent_class)->realize(widget);
 
 	GdkWindow* window = gtk_widget_get_window(widget);
@@ -148,40 +149,35 @@ static void carbon_child_realize(GtkWidget* widget) {
 	gtk_widget_set_app_paintable(widget, self->parentRelativeBg || self->isComposited);
 }
 
-static void carbon_child_get_preferred_width(GtkWidget* base, int* minimum_width, int* natural_width) {
-	CarbonChild* self = CARBON_CHILD(base);
-	int scale = gtk_widget_get_scale_factor(base);
-
-	*minimum_width = self->preferredWidth / scale;
-	*natural_width = self->preferredWidth / scale;
-}
-
-static void carbon_child_get_preferred_height(GtkWidget* base, int* minimum_height, int* natural_height) {
-	CarbonChild* self = CARBON_CHILD(base);
-	int scale = gtk_widget_get_scale_factor(base);
-
-	*minimum_height = self->preferredHeight / scale;
-	*natural_height = self->preferredHeight / scale;
+static void carbon_child_get_preferred_size(GtkWidget* base, int* minimum_size, int* natural_size) {
+	int preferredSize = CARBON_CHILD(base)->preferredSize;
+	*minimum_size = preferredSize;
+	*natural_size = preferredSize;
 }
 
 static void carbon_child_class_init(CarbonChildClass* klass) {
-	GtkWidgetClass* gtkwidget_class = GTK_WIDGET_CLASS(klass);
+	GtkWidgetClass* widget_class = GTK_WIDGET_CLASS(klass);
 
-	gtkwidget_class->get_preferred_width = carbon_child_get_preferred_width;
-	gtkwidget_class->get_preferred_height = carbon_child_get_preferred_height;
-	gtkwidget_class->realize = carbon_child_realize;
+	widget_class->get_preferred_width = carbon_child_get_preferred_size;
+	widget_class->get_preferred_height = carbon_child_get_preferred_size;
+	widget_class->realize = carbon_child_realize;
 }
 
-static void set_wmclass(CarbonChild* self, Display* xdisplay) {
+static bool set_wmclass(CarbonChild* self, Display* xdisplay) {
 	XClassHint ch;
-	ch.res_class = NULL;
 
 	GdkDisplay* display = gdk_display_get_default();
 	gdk_x11_display_error_trap_push(display);
 	XGetClassHint(xdisplay, self->iconWindow, &ch);
-	gdk_x11_display_error_trap_pop_ignored(display);
+	int error = gdk_x11_display_error_trap_pop(display);
 
-	if (ch.res_class) {
-		self->wmclass = ch.res_class;
+	if (error != 0) {
+		g_warning("Encountered X error %d when obtaining class hint for tray icon", error);
+		return FALSE;
 	}
+
+	if (ch.res_name != NULL) XFree(ch.res_name);
+	if (ch.res_class != NULL) self->wmclass = ch.res_class;
+
+	return TRUE;
 }

--- a/src/applets/tray/carbontray/child.c
+++ b/src/applets/tray/carbontray/child.c
@@ -63,8 +63,9 @@ CarbonChild* carbon_child_new(int size, GdkScreen* screen, Window iconWindow) {
 	}
 
 	GdkVisual* visual = gdk_x11_screen_lookup_visual(screen, attributes.visual->visualid);
-	if (visual == NULL || GDK_IS_VISUAL(visual) == FALSE)
+	if (visual == NULL || GDK_IS_VISUAL(visual) == FALSE) {
 		return NULL;
+	}
 
 	CarbonChild* self = g_object_new(CARBON_TYPE_CHILD, NULL);
 	self->preferredSize = size;
@@ -82,14 +83,16 @@ CarbonChild* carbon_child_new(int size, GdkScreen* screen, Window iconWindow) {
 		gdk_visual_get_green_pixel_details(visual, NULL, NULL, &green_prec);
 		gdk_visual_get_blue_pixel_details(visual, NULL, NULL, &blue_prec);
 
-		if (red_prec + blue_prec + green_prec < gdk_visual_get_depth(visual))
+		if (red_prec + blue_prec + green_prec < gdk_visual_get_depth(visual)) {
 			self->isComposited = TRUE;
+		}
 	}
 
 	self->wmclass = NULL;
-	if (!set_wmclass(self, xdisplay))
+	if (!set_wmclass(self, xdisplay)) {
 		// the icon window turned sour while we were getting alpha details. ignore the child
 		return NULL;
+	}
 
 	return self;
 }

--- a/src/applets/tray/carbontray/child.h
+++ b/src/applets/tray/carbontray/child.h
@@ -14,13 +14,13 @@
 
 #include <gtk/gtk.h>
 #include <gtk/gtkx.h>
+#include <X11/extensions/Xcomposite.h>
 #include <stdbool.h>
 
 typedef struct _CarbonChild {
 	GtkSocket parent;
 
-	int preferredWidth;
-	int preferredHeight;
+	int preferredSize;
 	Window iconWindow;
 
 	char* wmclass;

--- a/src/applets/tray/carbontray/meson.build
+++ b/src/applets/tray/carbontray/meson.build
@@ -2,6 +2,7 @@ libcarbontray_deps = [
     dep_gtk3,
     dependency('gtk+-x11-3.0'),
     dependency('x11'),
+    dependency('xcomposite'),
 ]
 
 libcarbontray_sources = [

--- a/src/applets/tray/carbontray/tray.c
+++ b/src/applets/tray/carbontray/tray.c
@@ -311,8 +311,9 @@ static bool handle_undock_request(GtkSocket* socket, void* userData) {
 
 static void handle_message_begin(CarbonTray* tray, XClientMessageEvent* xevent) {
 	GtkSocket* socket = g_hash_table_lookup(tray->socketTable, GUINT_TO_POINTER(xevent->window));
-	if (socket == NULL)
+	if (socket == NULL) {
 		return;
+	}		
 
 	remove_message(tray, xevent);
 

--- a/src/applets/tray/carbontray/tray.c
+++ b/src/applets/tray/carbontray/tray.c
@@ -73,10 +73,6 @@ CarbonTray* carbon_tray_new(GtkOrientation orientation, int iconSize, int spacin
 		gtk_widget_set_valign(self->box, GTK_ALIGN_START);
 	}
 
-	gtk_widget_set_hexpand(self->box, FALSE);
-	gtk_widget_set_vexpand(self->box, FALSE);
-	gtk_widget_set_size_request(self->box, -1, -1);
-
 	return self;
 }
 
@@ -95,7 +91,7 @@ bool carbon_tray_register(CarbonTray* tray, GdkScreen* screen) {
 	gtk_widget_realize(invisible);
 	gtk_widget_add_events(invisible, GDK_PROPERTY_CHANGE_MASK | GDK_STRUCTURE_MASK);
 
-	int screen_number = gdk_screen_get_number(screen);
+	int screen_number = XScreenNumberOfScreen(gdk_x11_screen_get_xscreen(screen));
 	char* selection_name = g_strdup_printf("_NET_SYSTEM_TRAY_S%d", screen_number);
 	tray->selectionAtom = gdk_atom_intern(selection_name, FALSE);
 	g_free(selection_name);
@@ -149,16 +145,15 @@ void carbon_tray_unregister(CarbonTray* tray) {
 	}
 
 	GtkWidget* invisible = tray->invisible;
+	GdkWindow* invisibleWindow = gtk_widget_get_window(invisible);
 	GdkDisplay* display = gtk_widget_get_display(invisible);
 	GdkWindow* owner = gdk_selection_owner_get_for_display(display, tray->selectionAtom);
 
 	if (owner == gtk_widget_get_window(invisible)) {
-		gdk_selection_owner_set_for_display(
-			display, NULL, tray->selectionAtom,
-			gdk_x11_get_server_time(gtk_widget_get_window(invisible)), TRUE);
+		gdk_selection_owner_set_for_display(display, NULL, tray->selectionAtom, gdk_x11_get_server_time(invisibleWindow), TRUE);
 	}
 
-	gdk_window_remove_filter(gtk_widget_get_window(invisible), window_filter, tray);
+	gdk_window_remove_filter(invisibleWindow, window_filter, tray);
 
 	tray->invisible = NULL;
 	gtk_widget_destroy(invisible);
@@ -405,40 +400,27 @@ static void set_xproperties(CarbonTray* tray) {
 		xvisual = GDK_VISUAL_XVISUAL(gdk_screen_get_system_visual(screen));
 	}
 
+	Display* xdisplay = GDK_DISPLAY_XDISPLAY(display);
+	Window xwindow = GDK_WINDOW_XID(gtk_widget_get_window(tray->invisible));
+
+	// set the RGBA visual
+
 	unsigned long data[1] = {XVisualIDFromVisual(xvisual)};
+	unsigned char* dataPtr = (unsigned char*) &data;
 	Atom atom = gdk_x11_get_xatom_by_name_for_display(display, "_NET_SYSTEM_TRAY_VISUAL");
-	XChangeProperty(
-		GDK_DISPLAY_XDISPLAY(display),
-		GDK_WINDOW_XID(gtk_widget_get_window(tray->invisible)),
-		atom, XA_VISUALID,
-		32,
-		PropModeReplace,
-		(guchar*) &data, 1);
+	XChangeProperty(xdisplay, xwindow, atom, XA_VISUALID, 32, PropModeReplace, dataPtr, 1);
 
 	// set the icon size
 
 	data[0] = (unsigned int) tray->iconSize;
 	atom = gdk_x11_get_xatom_by_name_for_display(display, "_NET_SYSTEM_TRAY_ICON_SIZE");
-	XChangeProperty(
-		GDK_DISPLAY_XDISPLAY(display),
-		GDK_WINDOW_XID(gtk_widget_get_window(tray->invisible)),
-		atom, XA_CARDINAL,
-		32,
-		PropModeReplace,
-		(guchar*) &data, 1);
+	XChangeProperty(xdisplay, xwindow, atom, XA_VISUALID, 32, PropModeReplace, dataPtr, 1);
 
-	// set orientation
+	// set the orientation
 
-	data[0] =
-		(unsigned int) gtk_orientable_get_orientation(GTK_ORIENTABLE(tray->box)) == GTK_ORIENTATION_HORIZONTAL ? 0 : 1;
+	data[0] = (unsigned int) gtk_orientable_get_orientation(GTK_ORIENTABLE(tray->box)) == GTK_ORIENTATION_HORIZONTAL ? 0 : 1;
 	atom = gdk_x11_get_xatom_by_name_for_display(display, "_NET_SYSTEM_TRAY_ORIENTATION");
-	XChangeProperty(
-		GDK_DISPLAY_XDISPLAY(display),
-		GDK_WINDOW_XID(gtk_widget_get_window(tray->invisible)),
-		atom, XA_CARDINAL,
-		32,
-		PropModeReplace,
-		(guchar*) &data, 1);
+	XChangeProperty(xdisplay, xwindow, atom, XA_VISUALID, 32, PropModeReplace, dataPtr, 1);
 }
 
 static void draw_child(GtkWidget* widget, void* data) {


### PR DESCRIPTION
## Description

This PR resolves a potential issue with Carbontray's window hint resolution that I never managed to catch in practice, but could certainly happen under the right conditions. In addition, it simplifies the code surrounding sizing of icons by assuming width and height will always be the same, as why would you want non-square icons? Finally, it replaces some deprecated GTK function calls with their X11 equivalents, because it's apparently fun to deprecate things (thanks GTK).

### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
