### PR TITLE
Resolve most compiler warnings

### DIFF
--- a/src/applets/budgie-menu/BudgieMenuWindow.vala
+++ b/src/applets/budgie-menu/BudgieMenuWindow.vala
@@ -221,7 +221,7 @@ public class BudgieMenuWindow : Budgie.Popover {
 		}
 
 		/* Activate the source_widget category */
-		(source_widget as Gtk.ToggleButton).set_active(true);
+		b.set_active(true);
 		return Gdk.EVENT_PROPAGATE;
 	}
 
@@ -527,7 +527,7 @@ public class BudgieMenuWindow : Budgie.Popover {
 			return true;
 		}
 
-		var keywords = (info as DesktopAppInfo).get_keywords();
+		var keywords = ((DesktopAppInfo) info).get_keywords();
 		if (keywords == null || keywords.length < 1) {
 			return false;
 		}

--- a/src/applets/icon-tasklist/DesktopHelper.vala
+++ b/src/applets/icon-tasklist/DesktopHelper.vala
@@ -48,7 +48,7 @@ public class DesktopHelper : GLib.Object {
 	public void update_pinned() {
 		string[] buttons = {};
 		foreach (Gtk.Widget widget in icon_layout.get_children()) {
-			IconButton button = (widget as ButtonWrapper).button;
+			IconButton button = ((ButtonWrapper) widget).button;
 
 			if (button.is_pinned()) {
 				if (button.get_appinfo() != null) {

--- a/src/applets/icon-tasklist/IconTasklistApplet.vala
+++ b/src/applets/icon-tasklist/IconTasklistApplet.vala
@@ -236,8 +236,8 @@ public class IconTasklistApplet : Budgie.Applet {
 				visible = button.is_pinned();
 			}
 
-			(button.get_parent() as ButtonWrapper).orient = this.get_orientation();
-			(button.get_parent() as Gtk.Revealer).set_reveal_child(visible);
+			((ButtonWrapper) button.get_parent()).orient = this.get_orientation();
+			((Gtk.Revealer) button.get_parent()).set_reveal_child(visible);
 			button.update();
 		});
 	}
@@ -412,7 +412,7 @@ public class IconTasklistApplet : Budgie.Applet {
 
 		main_layout.add(wrapper);
 		this.show_all();
-		(wrapper as Gtk.Revealer).set_reveal_child(false); // Default to not showing
+		((Gtk.Revealer) wrapper).set_reveal_child(false); // Default to not showing
 		this.update_buttons(); // Ensure we update the buttons at launch, determines immediately whether to show
 	}
 

--- a/src/applets/icon-tasklist/animation.vala
+++ b/src/applets/icon-tasklist/animation.vala
@@ -39,7 +39,7 @@ namespace BudgieTaskList {
 		public bool can_anim; /**<Whether we can animate ?*/
 		public int64 elapsed; /**<Elapsed time */
 		public bool no_reset; /**<Used sometimes for switching an animation*/
-		private AnimCompletionFunc compl;
+		private unowned AnimCompletionFunc compl;
 
 		private bool tick_callback(Gtk.Widget widget, Gdk.FrameClock frame) {
 			int64 time = frame.get_frame_time();

--- a/src/applets/keyboard-layout/KeyboardLayoutApplet.vala
+++ b/src/applets/keyboard-layout/KeyboardLayoutApplet.vala
@@ -391,22 +391,22 @@ public class KeyboardLayoutApplet : Budgie.Applet {
 
 			val.get_child(i, "(ss)", out id, out type);
 
-			if (id == "xkb") {
-				string[] spl = type.split("+");
-				string? variant = "";
-				if (spl.length > 1) {
-					variant = spl[1];
-				}
-				string desc = this.get_xkb_description(type);
-				source = new InputSource(this.ibus_manager, type, (uint)i, spl[0], variant, desc, true);
-				sources.append_val(source);
-			} else {
-				try {
+			try {
+				if (id == "xkb") {
+					string[] spl = type.split("+");
+					string? variant = "";
+					if (spl.length > 1) {
+						variant = spl[1];
+					}
+					string desc = this.get_xkb_description(type);
+					source = new InputSource(this.ibus_manager, type, (uint)i, spl[0], variant, desc, true);
+					sources.append_val(source);
+				} else {
 					source = new InputSource(this.ibus_manager, type, (uint)i, null, null, null, false);
 					sources.append_val(source);
-				} catch (Error e) {
-					message("Error adding source %s|%s: %s", id, type, e.message);
 				}
+			} catch (Error e) {
+				message("Error adding source %s|%s: %s", id, type, e.message);
 			}
 		}
 
@@ -445,10 +445,14 @@ public class KeyboardLayoutApplet : Budgie.Applet {
 			Gnome.get_input_source_from_locale(DEFAULT_LOCALE, out type, out id);
 		}
 
-		if (xkb.get_layout_info(id, out display_name, out short_name, out xkb_layout, out xkb_variant)) {
-			fallback = new InputSource(this.ibus_manager, id, 0, xkb_layout, xkb_variant, display_name, true);
-		} else {
-			fallback = new InputSource(this.ibus_manager, id, 0, DEFAULT_LAYOUT, DEFAULT_VARIANT, null, true);
+		try {
+			if (xkb.get_layout_info(id, out display_name, out short_name, out xkb_layout, out xkb_variant)) {
+				fallback = new InputSource(this.ibus_manager, id, 0, xkb_layout, xkb_variant, display_name, true);
+			} else {
+				fallback = new InputSource(this.ibus_manager, id, 0, DEFAULT_LAYOUT, DEFAULT_VARIANT, null, true);
+			}
+		} catch (Error e) {
+			message("Error updating fallback source %s: %s", id, e.message);
 		}
 	}
 

--- a/src/applets/lock-keys/LockKeysApplet.vala
+++ b/src/applets/lock-keys/LockKeysApplet.vala
@@ -32,7 +32,7 @@ public class LockKeysApplet : Budgie.Applet {
 		widget.pack_start(caps, false, false, 0);
 		widget.pack_start(num, false, false, 0);
 
-		map = Gdk.Keymap.get_default();
+		map = Gdk.Keymap.get_for_display(Gdk.Display.get_default());
 		map.state_changed.connect(on_state_changed);
 
 		on_state_changed();

--- a/src/applets/places-indicator/PlacesIndicatorWindow.vala
+++ b/src/applets/places-indicator/PlacesIndicatorWindow.vala
@@ -115,12 +115,12 @@ public class PlacesIndicatorWindow : Budgie.Popover {
 
 	public override void closed() {
 		foreach (Gtk.Widget item in mounts_listbox.get_children()) {
-			ListItem list_item = (ListItem) (item as Gtk.ListBoxRow).get_child();
+			ListItem list_item = (ListItem) ((Gtk.ListBoxRow) item).get_child();
 			list_item.cancel_operation();
 		}
 
 		foreach (Gtk.Widget item in networks_listbox.get_children()) {
-			ListItem list_item = (ListItem) (item as Gtk.ListBoxRow).get_child();
+			ListItem list_item = (ListItem) ((Gtk.ListBoxRow) item).get_child();
 			list_item.cancel_operation();
 		}
 

--- a/src/applets/raven-trigger/RavenTriggerApplet.vala
+++ b/src/applets/raven-trigger/RavenTriggerApplet.vala
@@ -121,7 +121,14 @@ public class RavenTriggerApplet : Budgie.Applet {
 	// Horrific work around to stop us getting caught up in our own dbus
 	// spam
 	private void* update_anchors() {
-		bool b = raven_proxy.GetLeftAnchored();
+		bool b;
+		try {
+			b = raven_proxy.GetLeftAnchored();
+		} catch (Error e) {
+			warning("Failed to get left anchored status of raven trigger for update: %s", e.message);
+			return null;
+		}
+
 		Gdk.threads_enter();
 		this.on_anchor_changed(b);
 		Gdk.threads_leave();

--- a/src/applets/spacer/SpacerApplet.vala
+++ b/src/applets/spacer/SpacerApplet.vala
@@ -74,6 +74,8 @@ public class SpacerApplet : Budgie.Applet {
 	}
 
 	public override void get_preferred_width(out int min, out int nat) {
+		min = -1;
+		nat = -1;
 		if (this.panel_position == Budgie.PanelPosition.TOP ||
 			this.panel_position == Budgie.PanelPosition.BOTTOM) {
 				min = nat = space_size;
@@ -81,6 +83,8 @@ public class SpacerApplet : Budgie.Applet {
 	}
 
 	public override void get_preferred_width_for_height(int h, out int min, out int nat) {
+		min = -1;
+		nat = -1;
 		if (this.panel_position == Budgie.PanelPosition.TOP ||
 			this.panel_position == Budgie.PanelPosition.BOTTOM) {
 				min = nat = space_size;
@@ -88,6 +92,8 @@ public class SpacerApplet : Budgie.Applet {
 	}
 
 	public override void get_preferred_height(out int min, out int nat) {
+		min = -1;
+		nat = -1;
 		if (this.panel_position == Budgie.PanelPosition.LEFT ||
 			this.panel_position == Budgie.PanelPosition.RIGHT) {
 				min = nat = space_size;
@@ -95,6 +101,8 @@ public class SpacerApplet : Budgie.Applet {
 	}
 
 	public override void get_preferred_height_for_width(int h, out int min, out int nat) {
+		min = -1;
+		nat = -1;
 		if (this.panel_position == Budgie.PanelPosition.LEFT ||
 			this.panel_position == Budgie.PanelPosition.RIGHT) {
 				min = nat = space_size;

--- a/src/applets/status/BluetoothIndicator.vala
+++ b/src/applets/status/BluetoothIndicator.vala
@@ -115,7 +115,8 @@ public class BluetoothIndicator : Gtk.Bin {
 		}
 	}
 
-	bool get_default_adapter(out Gtk.TreeIter adapter) {
+	bool get_default_adapter(out Gtk.TreeIter? adapter) {
+		adapter = null;
 		Gtk.TreeIter iter;
 
 		if (!model.get_iter_first(out iter)) {

--- a/src/applets/user-indicator/DBusInterfaces.vala
+++ b/src/applets/user-indicator/DBusInterfaces.vala
@@ -10,8 +10,8 @@
  */
 
 [DBus (name="org.freedesktop.Accounts")]
-interface AccountsInterface : GLib.Object {
-	public abstract string find_user_by_name(string username) throws IOError;
+interface AccountsInterface : Object {
+	public abstract string find_user_by_name(string username) throws DBusError, IOError;
 }
 
 [DBus (name="org.freedesktop.Accounts.User")]
@@ -20,21 +20,21 @@ interface AccountUserInterface : GLib.Object {
 }
 
 [DBus (name="org.freedesktop.DBus.Properties")]
-interface PropertiesInterface : GLib.Object {
-	public abstract Variant get(string interface, string property) throws IOError;
+interface PropertiesInterface : Object {
+	public abstract Variant get(string interface, string property) throws DBusError, IOError;
 	public signal void properties_changed();
 }
 
 /* logind */
 [DBus (name="org.freedesktop.login1.Manager")]
-public interface LogindInterface : GLib.Object {
-	public abstract void suspend(bool interactive) throws IOError;
-	public abstract void hibernate(bool interactive) throws IOError;
+public interface LogindInterface : Object {
+	public abstract void suspend(bool interactive) throws DBusError, IOError;
+	public abstract void hibernate(bool interactive) throws DBusError, IOError;
 }
 
 [DBus (name="org.gnome.SessionManager")]
-public interface SessionManager : GLib.Object {
-	public abstract void Logout(uint mode) throws IOError;
+public interface SessionManager : Object {
+	public abstract void Logout(uint mode) throws DBusError, IOError;
 	public abstract async void Reboot() throws Error;
 	public abstract async void Shutdown() throws Error;
 }

--- a/src/applets/user-indicator/UserIndicatorWindow.vala
+++ b/src/applets/user-indicator/UserIndicatorWindow.vala
@@ -32,8 +32,6 @@ public class UserIndicatorWindow : Budgie.Popover {
 	private IndicatorItem? user_item = null;
 
 	async void setup_dbus() {
-		var path = Environment.get_variable("XDG_SEAT_PATH");
-
 		try {
 			user_manager = yield Bus.get_proxy(BusType.SYSTEM, ACCOUNTSSERVICE_ACC, "/org/freedesktop/Accounts");
 

--- a/src/appsys/AppSystem.vala
+++ b/src/appsys/AppSystem.vala
@@ -236,7 +236,7 @@ namespace Budgie {
 			uint8[]? data = null;
 			Gdk.Atom a_type;
 			int a_f;
-			var display = Gdk.Display.get_default();
+			Gdk.X11.Display display = (Gdk.X11.Display) Gdk.Display.get_default();
 
 			Gdk.Atom req_type;
 			if (utf8) {
@@ -248,7 +248,7 @@ namespace Budgie {
 			/**
 			* Attempt to gain foreign window connection
 			*/
-			Gdk.Window? foreign = Gdk.X11Window.foreign_new_for_display(display, xid);
+			Gdk.Window? foreign = new Gdk.X11.Window.foreign_for_display(display, xid);
 			if (foreign == null) {
 				/* No window, bail */
 				return null;

--- a/src/daemon/endsession.vala
+++ b/src/daemon/endsession.vala
@@ -138,7 +138,7 @@ namespace Budgie {
 			});
 		}
 
-		public void Open(uint type, uint timestamp, uint open_length, ObjectPath[] inhibiters) {
+		public void Open(uint type, uint timestamp, uint open_length, ObjectPath[] inhibiters) throws DBusError, IOError {
 			Opened(); // Indicate that we've opened the EndSession dialog
 			/* Right now we ignore type, time and inhibitors. Shush */
 			unowned Gtk.Widget? main_show = null;
@@ -186,12 +186,12 @@ namespace Budgie {
 					w.hide();
 				}
 				main_show.show();
-				(main_show as Gtk.Bin).get_child().show();
+				((Gtk.Bin) main_show).get_child().show();
 			} else {
 				for (int i = 0; i < all_widgets.length; i++) {
 					unowned Gtk.Widget? w = all_widgets[i];
 					w.show();
-					(w as Gtk.Bin).get_child().show();
+					((Gtk.Bin) w).get_child().show();
 				}
 			}
 
@@ -206,14 +206,14 @@ namespace Budgie {
 				Gdk.Display? display = screen.get_display();
 
 				if (display is Gdk.X11.Display) {
-					win.focus((display as Gdk.X11.Display).get_user_time());
+					win.focus(((Gdk.X11.Display) display).get_user_time());
 				} else {
 					win.focus(Gtk.get_current_event_time());
 				}
 			}
 		}
 
-		public void Close() {
+		public void Close() throws DBusError, IOError {
 			hide();
 			Closed();
 		}

--- a/src/daemon/menus.vala
+++ b/src/daemon/menus.vala
@@ -130,7 +130,7 @@ namespace Budgie {
 		* We've been asked to display the root menu for the desktop itself,
 		* which contains actions for launching the settings, etc.
 		*/
-		public void ShowDesktopMenu(uint button, uint32 timestamp) {
+		public void ShowDesktopMenu(uint button, uint32 timestamp) throws DBusError, IOError {
 			Idle.add(() => {
 				if (desktop_menu.get_visible()) {
 					desktop_menu.hide();
@@ -144,7 +144,7 @@ namespace Budgie {
 		/**
 		* Show a window menu for the given window ID
 		*/
-		public void ShowWindowMenu(uint32 xid, uint button, uint32 timestamp) {
+		public void ShowWindowMenu(uint32 xid, uint button, uint32 timestamp) throws DBusError, IOError {
 			active_window = Wnck.Window.get(xid);
 			if (active_window == null) {
 				return;

--- a/src/daemon/osd.vala
+++ b/src/daemon/osd.vala
@@ -226,7 +226,7 @@ namespace Budgie {
 		* level: Progress-level to display in the OSD (double or int32 depending on gsd release)
 		* monitor: int32 The monitor to display the OSD on (currently ignored)
 		*/
-		public void ShowOSD(HashTable<string,Variant> params) {
+		public void ShowOSD(HashTable<string,Variant> params) throws DBusError, IOError {
 			string? icon_name = null;
 			string? label = null;
 

--- a/src/daemon/settings.vala
+++ b/src/daemon/settings.vala
@@ -106,8 +106,8 @@ namespace Budgie {
 		private void caffeine_settings_sync() {
 			gnome_session_settings.apply();
 			gnome_power_settings.apply();
-			gnome_session_settings.sync(); // Ensure write operations are complete for session
-			gnome_power_settings.sync(); // Ensure write operations are complete for power
+			Settings.sync(); // Ensure write operations are complete for session
+			Settings.sync(); // Ensure write operations are complete for power
 		}
 
 		/**
@@ -129,7 +129,7 @@ namespace Budgie {
 		private bool do_disable() {
 			if (get_caffeine_mode()) { // Is still disabled by the time our timer gets triggered
 				wm_settings.set_boolean("caffeine-mode", false);
-				wm_settings.sync();
+				Settings.sync();
 				reset_values(); // Immediately reset values
 			}
 
@@ -142,7 +142,7 @@ namespace Budgie {
 		public void do_disable_quietly() {
 			temporary_notification_disabled = true;
 			wm_settings.set_boolean("caffeine-mode", false);
-			wm_settings.sync();
+			Settings.sync();
 			reset_values(); // Immediately reset values
 		}
 
@@ -168,7 +168,7 @@ namespace Budgie {
 
 				temporary_notification_disabled = true;
 				wm_settings.set_boolean("caffeine-mode", false); // Ensure Caffeine Mode is disabled by default
-				wm_settings.sync();
+				Settings.sync();
 			}
 
 			get_power_defaults(); // Get our sleep ac and battery timeout defaults

--- a/src/daemon/tabswitcher.vala
+++ b/src/daemon/tabswitcher.vala
@@ -275,14 +275,14 @@ namespace Budgie {
 		* id: uint32 xid of the item
 		* title: string title of the window
 		*/
-		public void PassItem(uint32 id, uint32 usertime) {
+		public void PassItem(uint32 id, uint32 usertime) throws DBusError, IOError {
 			switcher_window.add_window(id, usertime);
 		}
 		/**
 		* Show the SWITCHER on screen with the given parameters:
 		* curr_xid: uint32 xid of the item to select
 		*/
-		public void ShowSwitcher(uint32 curr_xid) {
+		public void ShowSwitcher(uint32 curr_xid) throws DBusError, IOError {
 			this.add_mod_key_watcher();
 
 			switcher_window.move_switcher();
@@ -290,7 +290,7 @@ namespace Budgie {
 			switcher_window.focus_item(curr_xid);
 		}
 
-		public void StopSwitcher() {
+		public void StopSwitcher() throws DBusError, IOError {
 			switcher_window.stop_switching();
 		}
 

--- a/src/lib/animation.vala
+++ b/src/lib/animation.vala
@@ -39,7 +39,7 @@ namespace Budgie {
 		public bool can_anim; /**<Whether we can animate ?*/
 		public int64 elapsed; /**<Elapsed time */
 		public bool no_reset; /**<Used sometimes for switching an animation*/
-		private AnimCompletionFunc compl;
+		private unowned AnimCompletionFunc compl;
 
 		private bool tick_callback(Gtk.Widget widget, Gdk.FrameClock frame) {
 			int64 time = frame.get_frame_time();

--- a/src/libsession/libsession.vala
+++ b/src/libsession/libsession.vala
@@ -14,13 +14,13 @@ namespace LibSession {
 	 * Proxy for gnome-session
 	 */
 	[DBus (name="org.gnome.SessionManager")]
-	public interface SessionManager : GLib.Object {
-		public abstract async ObjectPath RegisterClient(string app_id, string client_start_id) throws IOError;
+	public interface SessionManager : Object {
+		public abstract async ObjectPath RegisterClient(string app_id, string client_start_id) throws DBusError, IOError;
 	}
 
 	[DBus (name="org.gnome.SessionManager.ClientPrivate")]
-	public interface SessionClient : GLib.Object {
-		public abstract void EndSessionResponse(bool is_ok, string reason) throws IOError;
+	public interface SessionClient : Object {
+		public abstract void EndSessionResponse(bool is_ok, string reason) throws DBusError, IOError;
 
 		public signal void Stop() ;
 		public signal void QueryEndSession(uint flags);

--- a/src/panel/panel.vala
+++ b/src/panel/panel.vala
@@ -53,7 +53,7 @@ namespace Budgie {
 	* The toplevel window for a panel
 	*/
 	public class Panel : Budgie.Toplevel {
-		Gtk.Box layout;
+		MainPanel layout;
 		Gtk.Box main_layout;
 		Gdk.Rectangle orig_scr;
 
@@ -189,7 +189,7 @@ namespace Budgie {
 		}
 
 		public void set_transparent(bool transparent) {
-			(layout as MainPanel).set_transparent(transparent);
+			layout.set_transparent(transparent);
 			this.update_dock_behavior();
 		}
 
@@ -577,7 +577,7 @@ namespace Budgie {
 			}
 
 			uuid = LibUUID.new(UUIDFlags.LOWER_CASE|UUIDFlags.TIME_SAFE_TYPE);
-			info = new AppletInfo(null, uuid, null, null);
+			info = new AppletInfo.from_uuid(uuid);
 			info.alignment = align;
 
 			/* Safety clamp */
@@ -641,7 +641,7 @@ namespace Budgie {
 						continue;
 					}
 
-					info = new AppletInfo(null, uuid, null, null);
+					info = new AppletInfo.from_uuid(uuid);
 					if (config.has_key(appl, "Alignment")) {
 						alignment = config.get_string(appl, "Alignment").strip();
 					}
@@ -935,7 +935,7 @@ namespace Budgie {
 		* we're in dock mode or not
 		*/
 		void update_dock_mode() {
-			(this.layout as MainPanel).set_dock_mode(this.dock_mode);
+			layout.set_dock_mode(this.dock_mode);
 			this.placement();
 		}
 

--- a/src/panel/settings/settings_applet_chooser.vala
+++ b/src/panel/settings/settings_applet_chooser.vala
@@ -115,8 +115,8 @@ namespace Budgie {
 		* Super simple sorting of applets in alphabetical listing
 		*/
 		int sort_applets(Gtk.ListBoxRow? a, Gtk.ListBoxRow? b) {
-			Peas.PluginInfo? infoA = (a.get_child() as PluginItem).plugin;
-			Peas.PluginInfo? infoB = (b.get_child() as PluginItem).plugin;
+			Peas.PluginInfo? infoA = ((PluginItem) a.get_child()).plugin;
+			Peas.PluginInfo? infoB = ((PluginItem) b.get_child()).plugin;
 
 			return strcmp(infoA.get_name().down(), infoB.get_name().down());
 		}
@@ -134,7 +134,7 @@ namespace Budgie {
 			this.button_ok.set_sensitive(true);
 
 			/* TODO: Switch name -> module_name */
-			this.applet_id = (row.get_child() as PluginItem).plugin.get_name();
+			this.applet_id = ((PluginItem) row.get_child()).plugin.get_name();
 		}
 
 		/**

--- a/src/panel/settings/settings_autostart.vala
+++ b/src/panel/settings/settings_autostart.vala
@@ -236,7 +236,7 @@ namespace Budgie {
 		}
 
 		private bool search_filter(Gtk.ListBoxRow row) {
-			AutostartItem item = (row as AutostartItemWidget).autostart_item;
+			AutostartItem item = ((AutostartItemWidget) row).autostart_item;
 			if (AutostartPage.autostart_files.contains(item.id)) {
 				return false;
 			}
@@ -280,7 +280,7 @@ namespace Budgie {
 
 			this.button_ok.set_sensitive(true);
 
-			this.selected_item = (row as AutostartItemWidget).autostart_item;
+			this.selected_item = ((AutostartItemWidget) row).autostart_item;
 		}
 
 		private void row_activated(Gtk.ListBoxRow? row) {

--- a/src/panel/settings/settings_main.vala
+++ b/src/panel/settings/settings_main.vala
@@ -45,7 +45,6 @@ namespace Budgie {
 			/* Have to override wmclass for pinning support */
 			set_icon_name("preferences-desktop");
 			set_title(_("Budgie Desktop Settings"));
-			set_wmclass("budgie-desktop-settings", "budgie-desktop-settings");
 
 			/* Fit even on a spud resolution */
 			set_default_size(750, 550);

--- a/src/panel/settings/settings_panel_applets.vala
+++ b/src/panel/settings/settings_panel_applets.vala
@@ -146,7 +146,7 @@ namespace Budgie {
 			Budgie.AppletInfo? info = null;
 
 			if (row != null) {
-				info = (row.get_child() as AppletItem).applet;
+				info = ((AppletItem) row.get_child()).applet;
 			}
 
 			/* Require applet info to be useful. */
@@ -343,10 +343,21 @@ namespace Budgie {
 		* Sort the list in accordance with alignment and actual position
 		*/
 		int do_sort(Gtk.ListBoxRow? before, Gtk.ListBoxRow? after) {
-			unowned Budgie.AppletInfo? before_info = (before.get_child() as AppletItem).applet;
-			unowned Budgie.AppletInfo? after_info = (after.get_child() as AppletItem).applet;
+			AppletItem? before_child = before.get_child() as AppletItem;
+			AppletItem? after_child = after.get_child() as AppletItem;
 
-			if (before_info != null && after_info != null && before_info.alignment != after_info.alignment) {
+			if (before_child == null || after_child == null) {
+				return 0;
+			}
+
+			unowned Budgie.AppletInfo? before_info = before_child.applet;
+			unowned Budgie.AppletInfo? after_info = after_child.applet;
+
+			if (before_info == null || after_info == null) {
+				return 0;
+			}
+
+			if (before_info.alignment != after_info.alignment) {
 				int bi = align_to_int(before_info.alignment);
 				int ai = align_to_int(after_info.alignment);
 
@@ -355,13 +366,7 @@ namespace Budgie {
 				} else {
 					return 1;
 				}
-			}
-
-			if (after_info == null) {
-				return 0;
-			}
-
-			if (before_info.position < after_info.position) {
+			} else if (before_info.position < after_info.position) {
 				return -1;
 			} else if (before_info.position > after_info.position) {
 				return 1;
@@ -380,12 +385,12 @@ namespace Budgie {
 			unowned Budgie.AppletInfo? after_info = null;
 
 			if (before != null) {
-				before_info = (before.get_child() as AppletItem).applet;
+				before_info = ((AppletItem) before.get_child()).applet;
 				prev = before_info.alignment;
 			}
 
 			if (after != null) {
-				after_info = (after.get_child() as AppletItem).applet;
+				after_info = ((AppletItem) after.get_child()).applet;
 				next = after_info.alignment;
 			}
 

--- a/src/panel/settings/settings_panel_dialogs.vala
+++ b/src/panel/settings/settings_panel_dialogs.vala
@@ -15,7 +15,6 @@ namespace Budgie {
 	* removed
 	*/
 	public class RemovePanelDialog : Gtk.Dialog {
-		Gtk.CheckButton check_confirm;
 		Gtk.Label confirm_label;
 		Gtk.Image confirm_image;
 

--- a/src/plugin/applet-info.c
+++ b/src/plugin/applet-info.c
@@ -222,6 +222,10 @@ static void budgie_applet_info_init(BudgieAppletInfo* self) {
 	self->priv = budgie_applet_info_get_instance_private(self);
 }
 
+BudgieAppletInfo* budgie_applet_info_new_from_uuid(const char* uuid) {
+	return g_object_new(BUDGIE_TYPE_APPLET_INFO, "uuid", uuid, NULL);
+}
+
 BudgieAppletInfo* budgie_applet_info_new(PeasPluginInfo* plugin_info, const char* uuid, BudgieApplet* applet, GSettings* settings) {
 	if (plugin_info) {
 		return g_object_new(

--- a/src/plugin/applet-info.h
+++ b/src/plugin/applet-info.h
@@ -49,6 +49,8 @@ struct _BudgieAppletInfo {
 	BudgieAppletInfoPrivate* priv;
 };
 
+BudgieAppletInfo* budgie_applet_info_new_from_uuid(const char* uuid);
+
 BudgieAppletInfo* budgie_applet_info_new(PeasPluginInfo* plugin_info, const char* uuid, BudgieApplet* applet, GSettings* settings);
 
 GType budgie_applet_info_get_type(void);

--- a/src/plugin/popover.c
+++ b/src/plugin/popover.c
@@ -706,12 +706,10 @@ static gboolean budgie_popover_draw(GtkWidget* widget, cairo_t* cr) {
 	GtkBorder border = {0};
 	GtkStateFlags fl;
 	BudgiePopover* self = NULL;
-	BudgieTail* tail = NULL;
 	GtkAllocation body_alloc = {0};
 	GtkWidget* child = NULL;
 
 	self = BUDGIE_POPOVER(widget);
-	tail = &(self->priv->tail);
 
 	/* Clear out the background before we draw anything */
 	cairo_save(cr);
@@ -724,9 +722,6 @@ static gboolean budgie_popover_draw(GtkWidget* widget, cairo_t* cr) {
 	gtk_widget_get_allocation(widget, &alloc);
 	body_alloc = alloc;
 
-	/* Set up the offset */
-	gdouble gap_start = 0, gap_end = 0;
-
 	body_alloc.x += SHADOW_DIMENSION;
 	body_alloc.width -= SHADOW_DIMENSION * 2;
 	body_alloc.y += SHADOW_DIMENSION;
@@ -737,28 +732,21 @@ static gboolean budgie_popover_draw(GtkWidget* widget, cairo_t* cr) {
 			body_alloc.height -= SHADOW_DIMENSION;
 			body_alloc.width -= TAIL_HEIGHT;
 			body_alloc.x += TAIL_HEIGHT;
-			gap_start = (tail->start_y + tail->y_offset);
 			break;
 		case GTK_POS_RIGHT:
 			body_alloc.height -= SHADOW_DIMENSION;
 			body_alloc.width -= TAIL_HEIGHT;
-			gap_start = tail->start_y + tail->y_offset;
 			break;
 		case GTK_POS_TOP: {
 			int diff = TAIL_HEIGHT - SHADOW_DIMENSION;
 			body_alloc.height -= SHADOW_DIMENSION * 2;
 			body_alloc.y += diff;
-			gap_start = (tail->start_x + tail->x_offset);
 		} break;
 		case GTK_POS_BOTTOM:
 		default:
 			body_alloc.height -= TAIL_HEIGHT;
-			gap_start = (tail->start_x + tail->x_offset);
 			break;
 	}
-
-	gap_start -= SHADOW_DIMENSION;
-	gap_end = gap_start + TAIL_DIMENSION;
 
 	fl = gtk_widget_get_state_flags(widget);
 
@@ -769,13 +757,10 @@ static gboolean budgie_popover_draw(GtkWidget* widget, cairo_t* cr) {
 	gtk_style_context_get_border(style, fl, &border);
 	gtk_render_background(style, cr, body_alloc.x, body_alloc.y, body_alloc.width, body_alloc.height);
 
-	gtk_render_frame_gap(
+	gtk_render_frame(
 		style, cr,
 		body_alloc.x, body_alloc.y,
-		body_alloc.width, body_alloc.height,
-		self->priv->tail.position,
-		gap_start,
-		gap_end);
+		body_alloc.width, body_alloc.height);
 	gtk_style_context_set_state(style, fl);
 
 	cairo_save(cr);

--- a/src/polkit/polkitdialog.vala
+++ b/src/polkit/polkitdialog.vala
@@ -208,10 +208,10 @@ namespace Budgie {
 				string? name = null;
 
 				if (ident is Polkit.UnixUser) {
-					unowned Posix.Passwd? pwd = Posix.getpwuid((ident as Polkit.UnixUser).get_uid());
+					unowned Posix.Passwd? pwd = Posix.getpwuid(((Polkit.UnixUser) ident).get_uid());
 					name = "%s".printf(pwd.pw_name);
 				} else if (ident is Polkit.UnixGroup) {
-					unowned Posix.Group? gwd = Posix.getgrgid((ident as Polkit.UnixGroup).get_gid());
+					unowned Posix.Group? gwd = Posix.getgrgid(((Polkit.UnixGroup) ident).get_gid());
 					name = "%s: %s".printf(_("Group:"), gwd.gr_name);
 				} else {
 					name = ident.to_string();

--- a/src/raven/headerwidget.vala
+++ b/src/raven/headerwidget.vala
@@ -14,7 +14,7 @@ namespace Budgie {
 	* Simple expander button for the header widget
 	*/
 	public class HeaderExpander : Gtk.Button {
-		private Gtk.Image? image;
+		private new Gtk.Image? image;
 
 		private bool _expanded = false;
 		private unowned HeaderWidget? owner = null;

--- a/src/raven/mpris/MprisClient.vala
+++ b/src/raven/mpris/MprisClient.vala
@@ -25,8 +25,8 @@ public class MprisClient : GLib.Object {
  * We need to probe the dbus daemon directly, hence this interface
  */
 [DBus (name="org.freedesktop.DBus")]
-public interface DBusImpl : GLib.Object {
-	public abstract async string[] list_names() throws IOError;
+public interface DBusImpl : Object {
+	public abstract async string[] list_names() throws DBusError, IOError;
 	public signal void name_owner_changed(string name, string old_owner, string new_owner);
 	public signal void name_acquired(string name);
 }

--- a/src/raven/mpris/MprisGui.vala
+++ b/src/raven/mpris/MprisGui.vala
@@ -250,17 +250,17 @@ public class ClientWidget : Gtk.Box {
 			case "Playing":
 				header.icon_name = "media-playback-start-symbolic";
 				header.text = "%s - Playing".printf(client.player.identity);
-				(play_btn.get_image() as Gtk.Image).set_from_icon_name("media-playback-pause-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
+				((Gtk.Image) play_btn.get_image()).set_from_icon_name("media-playback-pause-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
 				break;
 			case "Paused":
 				header.icon_name = "media-playback-pause-symbolic";
 				header.text = "%s - Paused".printf(client.player.identity);
-				(play_btn.get_image() as Gtk.Image).set_from_icon_name("media-playback-start-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
+				((Gtk.Image) play_btn.get_image()).set_from_icon_name("media-playback-start-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
 				break;
 			default:
 				header.text = client.player.identity;
 				header.icon_name = "media-playback-stop-symbolic";
-				(play_btn.get_image() as Gtk.Image).set_from_icon_name("media-playback-start-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
+				((Gtk.Image) play_btn.get_image()).set_from_icon_name("media-playback-start-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
 				break;
 		}
 	}

--- a/src/raven/notifications_view.vala
+++ b/src/raven/notifications_view.vala
@@ -172,12 +172,9 @@ namespace Budgie {
 		private Gtk.Label? label_body = null;
 
 		[GtkChild]
-		private Gtk.Button? button_close = null;
-
-		[GtkChild]
 		private Gtk.ButtonBox? box_actions = null;
 
-		public string? title;
+		public new string? title;
 		public string? body;
 		public Gdk.Pixbuf? pixbuf = null;
 		public int64 timestamp;
@@ -298,7 +295,6 @@ namespace Budgie {
 			int rowstride = img.get_child_value(2).get_int32();
 			bool has_alpha = img.get_child_value(3).get_boolean();
 			int bits_per_sample = img.get_child_value(4).get_int32();
-			int n_channels = img.get_child_value(5).get_int32();
 			// read the raw data
 			unowned uint8[] raw = (uint8[]) img.get_child_value(6).get_data();
 
@@ -528,11 +524,11 @@ namespace Budgie {
 		/* Obviously we'll change this.. */
 		private HashTable<uint32,NotificationWindow?> notifications;
 
-		public async string[] get_capabilities() {
+		public async string[] get_capabilities() throws DBusError, IOError {
 			return caps;
 		}
 
-		public void CloseNotification(uint32 id) {
+		public void CloseNotification(uint32 id) throws DBusError, IOError {
 			if (remove_notification(id)) {
 				this.NotificationClosed(id, NotificationCloseReason.CLOSED);
 			}
@@ -662,7 +658,7 @@ namespace Budgie {
 
 		public uint32 Notify(string app_name, uint32 replaces_id, string app_icon,
 							string summary, string body, string[] actions,
-							HashTable<string,Variant> hints, int32 expire_timeout) {
+							HashTable<string,Variant> hints, int32 expire_timeout) throws DBusError, IOError {
 			++notif_id;
 
 			/**
@@ -828,7 +824,7 @@ namespace Budgie {
 		public signal void ActionInvoked(uint32 id, string action_key);
 
 		public void GetServerInformation(out string name, out string vendor,
-										out string version, out string spec_version)  {
+										out string version, out string spec_version) throws DBusError, IOError {
 			name = "Raven";
 			vendor = "Budgie Desktop Developers";
 			version = Budgie.VERSION;

--- a/src/rundialog/RunDialog.vala
+++ b/src/rundialog/RunDialog.vala
@@ -14,8 +14,8 @@ namespace Budgie {
 	* We need to probe the dbus daemon directly, hence this interface
 	*/
 	[DBus (name="org.freedesktop.DBus")]
-	public interface DBusImpl : GLib.Object {
-		public abstract async string[] list_names() throws IOError;
+	public interface DBusImpl : Object {
+		public abstract async string[] list_names() throws DBusError, IOError;
 		public signal void name_owner_changed(string name, string old_owner, string new_owner);
 	}
 
@@ -163,7 +163,7 @@ namespace Budgie {
 		* Handle click/<enter> activation on the main list
 		*/
 		void on_row_activate(Gtk.ListBoxRow row) {
-			var child = (row as Gtk.Bin).get_child() as AppLauncherButton;
+			var child = ((Gtk.Bin) row).get_child() as AppLauncherButton;
 			this.launch_button(child);
 		}
 
@@ -174,7 +174,7 @@ namespace Budgie {
 			AppLauncherButton? act = null;
 			foreach (var row in app_box.get_children()) {
 				if (row.get_visible() && row.get_child_visible()) {
-					act = (row as Gtk.Bin).get_child() as AppLauncherButton;
+					act = ((Gtk.Bin) row).get_child() as AppLauncherButton;
 					break;
 				}
 			}

--- a/src/wm/shim.vala
+++ b/src/wm/shim.vala
@@ -67,7 +67,7 @@ namespace Budgie {
 			proxy = null;
 		}
 
-		public void Open(uint type, uint timestamp, uint open_length, ObjectPath[] inhibiters) {
+		public void Open(uint type, uint timestamp, uint open_length, ObjectPath[] inhibiters) throws DBusError, IOError {
 			if (proxy == null) {
 				return;
 			}
@@ -78,7 +78,7 @@ namespace Budgie {
 			}
 		}
 
-		public void Close() {
+		public void Close() throws DBusError, IOError {
 			if (proxy == null) {
 				try {
 					proxy.Close();
@@ -100,9 +100,9 @@ namespace Budgie {
 		public signal void Canceled();
 		public signal void Closed();
 
-		public abstract void Open(uint type, uint timestamp, uint open_length, ObjectPath[] inhibiters) throws Error;
+		public abstract void Open(uint type, uint timestamp, uint open_length, ObjectPath[] inhibiters) throws DBusError, IOError;
 
-		public abstract void Close() throws Error;
+		public abstract void Close() throws DBusError, IOError;
 	}
 
 	/**
@@ -119,7 +119,7 @@ namespace Budgie {
 		*   level: int32
 		*   monitor: int32
 		*/
-		public abstract async void ShowOSD(HashTable<string,Variant> params) throws Error;
+		public abstract async void ShowOSD(HashTable<string,Variant> params) throws DBusError, IOError;
 	}
 
 	[DBus (name="org.gnome.Shell")]
@@ -239,19 +239,19 @@ namespace Budgie {
 				on_bus_acquired, null, null);
 		}
 
-		public uint GrabAccelerator(BusName sender, string accelerator, uint flags, Meta.KeyBindingFlags grab_flags) {
+		public uint GrabAccelerator(BusName sender, string accelerator, uint flags, Meta.KeyBindingFlags grab_flags) throws DBusError, IOError {
 			return grab_accelerator(accelerator, grab_flags);
 		}
 
-		public uint[] GrabAccelerators(BusName sender, GsdAccel[] accelerators) {
+		public uint[] GrabAccelerators(BusName sender, GsdAccel[] accelerators) throws DBusError, IOError {
 			return grab_accelerators(accelerators);
 		}
 
-		public bool UngrabAccelerator(BusName sender, uint action) {
+		public bool UngrabAccelerator(BusName sender, uint action) throws DBusError, IOError {
 			return ungrab_accelerator(action);
 		}
 
-		public bool UngrabAccelerators(BusName sender, uint[] actions) {
+		public bool UngrabAccelerators(BusName sender, uint[] actions) throws DBusError, IOError {
 			foreach (uint action in actions) {
 				ungrab_accelerator(action);
 			}
@@ -261,7 +261,7 @@ namespace Budgie {
 		/**
 		* Show the OSD when requested.
 		*/
-		public void ShowOSD(HashTable<string,Variant> params) {
+		public void ShowOSD(HashTable<string,Variant> params) throws DBusError, IOError {
 			if (osd_proxy != null) {
 				osd_proxy.ShowOSD.begin(params);
 			}

--- a/src/wm/wm.vala
+++ b/src/wm/wm.vala
@@ -407,12 +407,12 @@ namespace Budgie {
 			Pid pid = Meta.Util.show_dialog("--question",
 							"Does the display look OK?",
 							"20",
-							null,
+							"",
 							"_Keep This Configuration",
 							"_Restore Previous Configuration",
 							"preferences-desktop-display",
 							0,
-							null, null);
+							new SList<void*>(), new SList<void*>());
 
 			ChildWatch.add(pid, on_dialog_closed);
 		}
@@ -666,11 +666,6 @@ namespace Budgie {
 
 		void map_done(Clutter.Actor? actor) {
 			SignalHandler.disconnect_by_func(actor, (void*)map_done, this);
-			finalize_animations(actor as Meta.WindowActor);
-		}
-
-		void notification_map_done(Clutter.Actor? actor) {
-			SignalHandler.disconnect_by_func(actor, (void*)notification_map_done, this);
 			finalize_animations(actor as Meta.WindowActor);
 		}
 
@@ -997,6 +992,7 @@ namespace Budgie {
 			}
 			return 0;
 		}
+
 		static int tab_sort_reverse(Meta.Window a, Meta.Window b) {
 			uint32 at;
 			uint32 bt;
@@ -1230,7 +1226,7 @@ namespace Budgie {
 
 			if (use_animations) { // If animations are enabled
 				foreach (var actor in Meta.Compositor.get_window_actors(display)) {
-					var window = (actor as Meta.WindowActor).get_meta_window();
+					var window = ((Meta.WindowActor) actor).get_meta_window();
 
 					if (!window.showing_on_its_workspace() || window.is_on_all_workspaces()) {
 						continue;
@@ -1332,15 +1328,15 @@ namespace Budgie {
 				on_bus_acquired, null, null);
 		}
 
-		public void store_focused() {
+		public void store_focused() throws DBusError, IOError {
 			this.wm.store_focused();
 		}
 
-		public void restore_focused() {
+		public void restore_focused() throws DBusError, IOError {
 			this.wm.restore_focused();
 		}
 
-		public void RemoveWorkspaceByIndex(int index, uint32 time) {
+		public void RemoveWorkspaceByIndex(int index, uint32 time) throws DBusError, IOError {
 			unowned Meta.WorkspaceManager wsm = this.wm.get_display().get_workspace_manager();
 			unowned Meta.Workspace? workspace = wsm.get_workspace_by_index(index);
 			if (workspace == null) {
@@ -1349,7 +1345,7 @@ namespace Budgie {
 			wsm.remove_workspace(workspace, time);
 		}
 
-		public int AppendNewWorkspace(uint32 time) {
+		public int AppendNewWorkspace(uint32 time) throws DBusError, IOError {
 			unowned Meta.WorkspaceManager wsm = this.wm.get_display().get_workspace_manager();
 			int current_count = wsm.get_n_workspaces(); // Get the current count
 


### PR DESCRIPTION
## Description
Resolve most compiler warnings in Budgie source, while only disabling one warning. This generally consists of the following:

- Adding try/catch when it's necessary
- Replacing `variable as Type` with `(Type) variable` in places where the safe cast was being ignored anyway
- Removing unused functions and variables
- Replacing deprecated functions with their non-deprecated equivalents (thanks GNOME devs)
- Changing semantics so that the Vala transpiler stops complaining
- Adding `throws DBusError` to DBus functions even if they don't throw DBusError

I look forward to the inevitable change requests.

### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
