### PR TITLE
Reformat carbontray files and fix compositing

### DIFF
--- a/src/applets/tray/carbontray/carbontray-1.0.vapi
+++ b/src/applets/tray/carbontray/carbontray-1.0.vapi
@@ -1,7 +1,7 @@
 namespace Carbon {
     [Compact]
     [CCode (cheader_filename="tray.h")]
-	public class Tray : GLib.Object {
+	public class Tray : Object {
         [CCode (has_construct_function=false, type = "GtkWidget*")]
         public Tray(Gtk.Orientation orientation, int iconSize, int spacing);
 

--- a/src/applets/tray/carbontray/child.c
+++ b/src/applets/tray/carbontray/child.c
@@ -143,13 +143,13 @@ static void carbon_child_realize(GtkWidget* widget) {
 
 	if (self->isComposited) {
 		XSetWindowBackground(xdisplay, xwindow, 0);
-		XCompositeRedirectWindow(xdisplay, xwindow, CompositeRedirectManual);
 	} else if (gtk_widget_get_visual(widget) == gdk_window_get_visual(gdk_window_get_parent(window))) {
 		XSetWindowBackgroundPixmap(xdisplay, xwindow, None);
 	} else {
 		self->parentRelativeBg = FALSE;
 	}
 
+	gdk_window_set_composited(window, self->isComposited);
 	gtk_widget_set_app_paintable(widget, self->parentRelativeBg || self->isComposited);
 }
 

--- a/src/applets/tray/carbontray/child.h
+++ b/src/applets/tray/carbontray/child.h
@@ -12,9 +12,9 @@
 #ifndef __CARBON_CHILD_H__
 #define __CARBON_CHILD_H__
 
+#include <X11/extensions/Xcomposite.h>
 #include <gtk/gtk.h>
 #include <gtk/gtkx.h>
-#include <X11/extensions/Xcomposite.h>
 #include <stdbool.h>
 
 typedef struct _CarbonChild {

--- a/src/applets/tray/carbontray/tray.c
+++ b/src/applets/tray/carbontray/tray.c
@@ -313,7 +313,7 @@ static void handle_message_begin(CarbonTray* tray, XClientMessageEvent* xevent) 
 	GtkSocket* socket = g_hash_table_lookup(tray->socketTable, GUINT_TO_POINTER(xevent->window));
 	if (socket == NULL) {
 		return;
-	}		
+	}
 
 	remove_message(tray, xevent);
 


### PR DESCRIPTION
## Description
This PR runs ./update_format.sh, reformatting some carbontray source files. It also partially reverts #2038, as that PR caused an issue with redrawing when the display was reloaded.


### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
