### PR TITLE
Resolve mutter 7 minimize animations / 4K animation - Fixes #2040

### DIFF
--- a/vapi/libmutter-6.vapi
+++ b/vapi/libmutter-6.vapi
@@ -154,6 +154,7 @@ namespace Meta {
 		public static unowned Meta.Backend get_backend ();
 		public unowned Meta.Dnd get_dnd ();
 		public unowned Meta.RemoteAccessController get_remote_access_controller ();
+		public unowned Meta.Settings get_settings ();
 		public unowned Clutter.Actor get_stage ();
 		public void lock_layout_group (uint idx);
 		public void set_keymap (string layouts, string variants, string options);

--- a/vapi/libmutter-7.vapi
+++ b/vapi/libmutter-7.vapi
@@ -156,6 +156,7 @@ namespace Meta {
 		public static unowned Meta.Backend get_backend ();
 		public unowned Meta.Dnd get_dnd ();
 		public unowned Meta.RemoteAccessController get_remote_access_controller ();
+		public unowned Meta.Settings get_settings ();
 		public unowned Clutter.Actor get_stage ();
 		public bool is_rendering_hardware_accelerated ();
 		public void lock_layout_group (uint idx);


### PR DESCRIPTION
## Description
Mutter 7 removes the deprecated scaled-gravity animation
that budgie desktop previously used.  This patch replaces this
with the recommended clutter equivalents.
In addition, the window minimize/unminimize animation did not
account for scaling factors so on 4K desktops the animation
was broken.  This patch resolves this as well.
Mutter 6 & 7 Actor performance improvements makes
the existing animation effect a little 'flashy'.  This patch
increases the transition speed by 30ms - so no real effect
on user control, but improves the smoothness of the animation
effect.

### Submitter Checklist

- [X] Squashed commits with `git rebase -i` (if needed)
- [X] Built budgie-desktop and verified that the patch worked (if needed)
