### PR TITLE
Obtain gsettings transparency key value before showing the panel

### DIFF
--- a/src/panel/manager.vala
+++ b/src/panel/manager.vala
@@ -1233,6 +1233,11 @@ namespace Budgie {
 			load_panel(uuid, false);
 
 			set_panels();
+
+			string path = this.create_panel_path(uuid);
+			var settings = new GLib.Settings.with_path(Budgie.TOPLEVEL_SCHEMA, path);
+			transparency = (PanelTransparency)settings.get_enum(Budgie.PANEL_KEY_TRANSPARENCY);
+
 			show_panel(uuid, position, transparency);
 
 			if (new_defaults == null || name == null) {


### PR DESCRIPTION
## Description
When creating a panel, the transparency key value needs to be obtained
before showing the panel. This allows transparency panel gsettings overrides.

This patch has been in use on Debian/Ubuntu since 2018 
(PR https://github.com/solus-project/budgie-desktop/pull/1251)

Resubmitted at the request of Josh.

### Submitter Checklist

- [X] Squashed commits with `git rebase -i` (if needed)
- [X] Built budgie-desktop and verified that the patch worked (if needed)
