### PR TITLE
Implement setting to choose which side of the screen Raven opens on

### DIFF
--- a/src/panel/settings/settings_raven.vala
+++ b/src/panel/settings/settings_raven.vala
@@ -14,6 +14,7 @@ namespace Budgie {
 	* RavenPage shows options for configuring Raven
 	*/
 	public class RavenPage : Budgie.SettingsPage {
+		private Gtk.ComboBox? raven_position;
 		private Gtk.Switch? allow_volume_overdrive;
 		private Gtk.Switch? enable_week_numbers;
 		private Gtk.Switch? show_calendar_widget;
@@ -33,6 +34,33 @@ namespace Budgie {
 
 			var grid = new SettingsGrid();
 			this.add(grid);
+
+			raven_position = new Gtk.ComboBox();
+
+			// Add options for Raven position
+			var render = new Gtk.CellRendererText();
+			var model = new Gtk.ListStore(3, typeof(string), typeof(string), typeof(RavenPosition));
+			Gtk.TreeIter iter;
+			const RavenPosition[] positions = {
+				RavenPosition.AUTOMATIC,
+				RavenPosition.LEFT,
+				RavenPosition.RIGHT
+			};
+
+			foreach (var pos in positions) {
+				model.append(out iter);
+				model.set(iter, 0, pos.to_string(), 1, pos.get_display_name(), 2, pos, -1);
+			}
+
+			raven_position.set_model(model);
+			raven_position.pack_start(render, true);
+			raven_position.add_attribute(render, "text", 1);
+			raven_position.set_id_column(0);
+
+			grid.add_row(new SettingsRow(raven_position,
+				_("Set Raven position"),
+				_("Set which side of the screen Raven will open on. If set to Automatic, Raven will open where its parent panel is.")
+			));
 
 			allow_volume_overdrive = new Gtk.Switch();
 			grid.add_row(new SettingsRow(allow_volume_overdrive,
@@ -76,6 +104,7 @@ namespace Budgie {
 			));
 
 			raven_settings = new Settings("com.solus-project.budgie-raven");
+			raven_settings.bind("raven-position", raven_position, "active-id", SettingsBindFlags.DEFAULT);
 			raven_settings.bind("allow-volume-overdrive", allow_volume_overdrive, "active", SettingsBindFlags.DEFAULT);
 			raven_settings.bind("enable-week-numbers", enable_week_numbers, "active", SettingsBindFlags.DEFAULT);
 			raven_settings.bind("show-calendar-widget", show_calendar_widget, "active", SettingsBindFlags.DEFAULT);

--- a/src/raven/com.solus-project.budgie.raven.gschema.xml
+++ b/src/raven/com.solus-project.budgie.raven.gschema.xml
@@ -1,7 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schemalist gettext-domain="budgie-desktop">
 
+  <enum id="com.solus-project.budgie-raven.RavenPosition">
+    <value nick="BUDGIE_RAVEN_POSITION_AUTOMATIC" value="1" />
+    <value nick="BUDGIE_RAVEN_POSITION_LEFT" value="2" />
+    <value nick="BUDGIE_RAVEN_POSITION_RIGHT" value="3" />
+  </enum>
+
   <schema path="/com/solus-project/budgie-raven/" id="com.solus-project.budgie-raven">
+    <key enum="com.solus-project.budgie-raven.RavenPosition" name="raven-position">
+      <default>'BUDGIE_RAVEN_POSITION_AUTOMATIC'</default>
+      <summary>Set Raven position</summary>
+      <description>Set which side of the screen Raven will open on. If set to Automatic, Raven will open where its parent panel is.</description>
+    </key>
+
     <key type="b" name="allow-volume-overdrive">
       <default>false</default>
       <summary>Allow raising volume above 100%</summary>

--- a/src/raven/main_view.vala
+++ b/src/raven/main_view.vala
@@ -102,6 +102,12 @@ namespace Budgie {
 		* on_raven_settings_changed will handle when the settings for Raven widgets have changed
 		*/
 		void on_raven_settings_changed(string key) {
+			// This key is handled by the panel manager instead of Raven directly.
+			// Moreover, it isn't a boolean so it logs a Critical message on the get_boolean() below.
+			if (key == "raven-position") {
+				return;
+			}
+
 			bool show_widget = raven_settings.get_boolean(key);
 
 			/**

--- a/src/raven/raven.vala
+++ b/src/raven/raven.vala
@@ -13,6 +13,33 @@ namespace Budgie {
 	public const string RAVEN_DBUS_NAME = "org.budgie_desktop.Raven";
 	public const string RAVEN_DBUS_OBJECT_PATH = "/org/budgie_desktop/Raven";
 
+	/**
+	 * Possible positions for Raven to be in.
+	 *
+	 * Automatic positioning will make Raven open on whichever side
+	 * of the screen that the Raven toggle button is on.
+	 */
+	public enum RavenPosition {
+		AUTOMATIC = 1,
+		LEFT = 2,
+		RIGHT = 3;
+
+		/**
+		 * Get a user-friendly localized name for the position.
+		 */
+		public string get_display_name() {
+			switch (this) {
+			case RavenPosition.LEFT:
+				return _("Left");
+			case RavenPosition.RIGHT:
+				return _("Right");
+			case RavenPosition.AUTOMATIC:
+			default:
+				return _("Automatic");
+			}
+		}
+	}
+
 	[DBus (name="org.budgie_desktop.Raven")]
 	public class RavenIface {
 		private Raven? parent = null;


### PR DESCRIPTION
## Description
This pull requests adds a setting in the Raven section of Budgie Desktop Settings to allow users to choose which side of the screen Raven opens on. By default, it is set to Automatic, which preserves the current logic that Raven uses to decide where to open.

~~I'm marking this as a draft for the moment because there is something weird going on that I haven't figured out yet, and I'm hoping that more eyes will help. The implementation works as expected and the Raven behavior changes correctly, but when the setting is changed, a GLib-Critical message (when running from the terminal) is logged:~~

Additionally, the gschema enum names are super ugly, but I'm not sure of 1) if it matters, and 2) the best way to improve it.

Closes #1490 

### Submitter Checklist

- [ ] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
