### PR TITLE
Update carbontray and fix its copyright headers

### DIFF
--- a/src/applets/tray/carbontray/child.h
+++ b/src/applets/tray/carbontray/child.h
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2015-2020 Budgie Desktop Developers
+ * Copyright © 2020 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -43,7 +43,9 @@ typedef struct _CarbonChildClass {
 
 GType carbon_child_get_type(void);
 
-CarbonChild* carbon_child_new(int, GdkScreen*, Window);
+CarbonChild* carbon_child_new(int, bool, GdkScreen*, Window);
+
+bool carbon_child_realize(CarbonChild*);
 
 void carbon_child_draw_on_tray(CarbonChild*, GtkWidget*, cairo_t*);
 

--- a/src/applets/tray/carbontray/tray.h
+++ b/src/applets/tray/carbontray/tray.h
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2015-2020 Budgie Desktop Developers
+ * Copyright © 2020 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -23,6 +23,7 @@ typedef struct {
 
 	GtkWidget* box;
 	int iconSize;
+	bool supportsComposite;
 
 	GHashTable* socketTable;
 	GtkWidget* invisible;


### PR DESCRIPTION
## Description
- The composite extension is now queried on tray creation, not child creation
- Additional error checking added to composite enablement. Hopefully resolves Wine-related panel crashing
- Changed "2015-2020" to just "2020" to better reflect the actual copyright duration for carbontray source

### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
