### PR TITLE
Precise fullscreen tracking in Abomination

### DIFF
--- a/src/abomination/abomination.vala
+++ b/src/abomination/abomination.vala
@@ -132,14 +132,14 @@ namespace Budgie {
 			});
 
 			app.window.state_changed.connect((changed, new_state) => {
-				bool now_fullscreen = window.is_fullscreen();
-
-				if (now_fullscreen) {
-					fullscreen_windows.insert(window.get_name(), window); // Add to fullscreen_windows
-					toggle_night_light(false); // Toggle the night light off if possible
-				} else {
-					fullscreen_windows.steal(window.get_name()); // Remove from fullscreen_windows
-					toggle_night_light(true); // Toggle the night light back on if possible
+				if (Wnck.WindowState.FULLSCREEN in changed) {
+					if (new_state == Wnck.WindowState.FULLSCREEN) {
+						fullscreen_windows.insert(window.get_name(), window); // Add to fullscreen_windows
+						toggle_night_light(false); // Toggle the night light off if possible
+					} else {
+						fullscreen_windows.steal(window.get_name()); // Remove from fullscreen_windows
+						toggle_night_light(true); // Toggle the night light back on if possible
+					}
 				}
 			});
 		}


### PR DESCRIPTION
## Description
This PR modifies the fullscreen detection behavior in Abomination. Instead of adding/stealing fullscreen windows from the list of fullscreen windows every time a window's state changes, the lambda now uses the bit mask to check if the fullscreen status itself actually changed. This leads to far more precise detection, avoiding potential issues with expansion of this functionality.

### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
