### PR TITLE
Fix issues with nightlight auto-toggling

### DIFF
--- a/src/abomination/abomination.vala
+++ b/src/abomination/abomination.vala
@@ -135,10 +135,13 @@ namespace Budgie {
 				if (Wnck.WindowState.FULLSCREEN in changed) {
 					if (new_state == Wnck.WindowState.FULLSCREEN) {
 						fullscreen_windows.insert(window.get_name(), window); // Add to fullscreen_windows
-						toggle_night_light(false); // Toggle the night light off if possible
 					} else {
 						fullscreen_windows.steal(window.get_name()); // Remove from fullscreen_windows
-						toggle_night_light(true); // Toggle the night light back on if possible
+					}
+
+					// only toggle the nightlight if there's zero or one fullscreen window
+					if (fullscreen_windows.size() <= 1) {
+						toggle_night_light(fullscreen_windows.size() == 0); // if zero, enable. if one, disable
 					}
 				}
 			});
@@ -169,6 +172,11 @@ namespace Budgie {
 			AbominationRunningApp app = running_apps_id.get(id); // Get the running app
 
 			running_apps_id.steal(id); // Remove from running_apps_id
+
+			fullscreen_windows.steal(window.get_name()); // Remove from fullscreen windows list
+			if (fullscreen_windows.size() <= 1) {
+				toggle_night_light(fullscreen_windows.size() == 0); // if zero, enable. if one, disable
+			}
 
 			if (app != null) { // App is defined
 				Array<AbominationRunningApp> group_apps = running_apps.get(app.group); // Get apps based on group name


### PR DESCRIPTION
## Description
This PR fixes two issues.

#### The First

Budgie master currently toggles nightlight on or off whenever a window obtains or discards fullscreen. This could present potential issues if multiple windows are in fullscreen, like in multi-monitor setups. This patch adds an additional check, to only toggle nightlight if one or zero windows have fullscreen. Thus, if more than one window has fullscreen, nightlight will already be disabled and this check will prevent nightlight state changes until only one fullscreen window is left.

#### The Second

The current fullscreen checking works fine... until a fullscreen window closes before changing back to windowed mode. If this happens, the window stays in the `fullscreen_windows` table, and nightlight never gets re-enabled. This patch adds code to the `remove_app` function that removes closing windows from the fullscreen table, and enables/disables nightlight if required.

### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
