### PR TITLE
Apply dock mode class on init

### DIFF
--- a/src/panel/panel.vala
+++ b/src/panel/panel.vala
@@ -331,6 +331,7 @@ namespace Budgie {
 			this.settings.bind(Budgie.PANEL_KEY_DOCK_MODE, this, "dock-mode", SettingsBindFlags.DEFAULT);
 
 			this.notify["dock-mode"].connect(this.update_dock_mode);
+			layout.set_dock_mode(this.dock_mode);
 
 			shadow_visible = this.settings.get_boolean(Budgie.PANEL_KEY_SHADOW);
 			this.settings.bind(Budgie.PANEL_KEY_SHADOW, this, "shadow-visible", SettingsBindFlags.DEFAULT);


### PR DESCRIPTION
## Description

All this PR does is apply the `dock-mode` class on panel initialization if need be. This fixes an issue wherein the class would only be applied after the dock mode setting was changed. 

### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
