### PR TITLE
Fix #2071, an issue with KeePass causing panel segfaults

### DIFF
--- a/src/applets/tray/carbontray/child.c
+++ b/src/applets/tray/carbontray/child.c
@@ -168,7 +168,7 @@ static void carbon_child_class_init(CarbonChildClass* klass) {
 }
 
 static bool set_wmclass(CarbonChild* self, Display* xdisplay) {
-	XClassHint ch;
+	XClassHint ch = {};
 
 	GdkDisplay* display = gdk_display_get_default();
 	gdk_x11_display_error_trap_push(display);


### PR DESCRIPTION
## Description

This PR resolves an issue with carbontray wherein an application icon that does not set an X class hint could cause the panel to crash. Why was this an issue to begin with? Well, I'm an idiot.

Fixes #2071.

### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
