### PR TITLE
Fix regression in Budgie Desktop Settings icon handling

### DIFF
--- a/src/panel/settings/settings_main.vala
+++ b/src/panel/settings/settings_main.vala
@@ -66,6 +66,7 @@ namespace Budgie {
 			/* Have to override wmclass for pinning support */
 			set_icon_name("preferences-desktop");
 			set_title(_("Budgie Desktop Settings"));
+			set_wmclass("budgie-desktop-settings", "budgie-desktop-settings");
 
 			/* Fit even on a spud resolution */
 			set_default_size(750, 550);


### PR DESCRIPTION
## Description
Fixes #2081.

### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
