### PR TITLE
Raven/SoundIndicator: Use standard mute/unmute method

### DIFF
--- a/src/applets/status/SoundIndicator.vala
+++ b/src/applets/status/SoundIndicator.vala
@@ -18,8 +18,6 @@ public class SoundIndicator : Gtk.Bin {
 	/** Our mixer */
 	public Gvc.MixerControl mixer { protected set ; public get ; }
 
-	public uint32 unmuted_volume_val = 0;
-
 	/** Default stream */
 	private Gvc.MixerStream? stream;
 
@@ -234,19 +232,7 @@ public class SoundIndicator : Gtk.Bin {
 
 	// toggle_mute_state will toggle the volume between muted and unmuted
 	private void toggle_mute_state() {
-		/**
-		 * You're probably wonder "hey, why aren't you using set_is_muted and get_is_muted"?
-		 * Great question. It doesn't work for toggling these values. Simple.
-		 */
-		bool is_muted = stream.get_volume() == 0;
-
-		if (is_muted) { // If we're muted
-			stream.set_volume(unmuted_volume_val); // Used our old value
-		} else {
-			stream.set_volume(0); // Set to 0
-		}
-
-		Gvc.push_volume(stream);
+		stream.change_is_muted(!stream.get_is_muted());
 	}
 
 	/**
@@ -308,10 +294,6 @@ public class SoundIndicator : Gtk.Bin {
 
 		show_all();
 		queue_draw();
-
-		if (stream.get_volume() != 0) { // If we haven't muted
-			unmuted_volume_val = stream.get_volume(); // Get our new volume
-		}
 	}
 
 	/**


### PR DESCRIPTION
## Description
<Info on what this pull request adds>
Uses the standard methods for muting/unmuting audio in the StatusIndicator applet and Raven, instead of the current volume hack.

Fixes issues like muting with media keys and then trying to unmute via the applet, which would previously not work. Also in Raven it seems I couldn't unmute apps via the button before.

### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
