### PR TITLE
Add spacing setting to StatusApplet

### DIFF
--- a/src/applets/status/com.solus-project.status.gschema.xml
+++ b/src/applets/status/com.solus-project.status.gschema.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schemalist gettext-domain="budgie">
+  <schema id="com.solus-project.status">
+    <key type="i" name="spacing">
+      <default>6</default>
+      <summary>Space between icons</summary>
+      <description>How large to make the space between icons, in pixels</description>
+    </key>
+  </schema>
+</schemalist>

--- a/src/applets/status/meson.build
+++ b/src/applets/status/meson.build
@@ -9,11 +9,21 @@ custom_target('plugin-file-status',
     install : true,
     install_dir : applet_status_dir)
 
+gresource = join_paths(meson.current_source_dir(), 'plugin.gresource.xml')
+
+applet_status_resources = gnome.compile_resources(
+    'status-applet-resources',
+    gresource,
+    source_dir: meson.current_source_dir(),
+    c_name: 'budgie_status',
+)
+
 applet_status_sources = [
     'BluetoothIndicator.vala',
     'StatusApplet.vala',
     'PowerIndicator.vala',
     'SoundIndicator.vala',
+    applet_status_resources
 ]
 
 applet_status_deps = [
@@ -46,4 +56,9 @@ shared_library(
     install: true,
     install_dir: applet_status_dir,
     install_rpath: rpath_libdir,
+)
+
+install_data(
+    'com.solus-project.status.gschema.xml',
+    install_dir: join_paths(datadir, 'glib-2.0', 'schemas'),
 )

--- a/src/applets/status/plugin.gresource.xml
+++ b/src/applets/status/plugin.gresource.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gresources>
+        <gresource prefix="/com/solus-project/status">
+                <file preprocess="xml-stripblanks">settings.ui</file>
+        </gresource>
+</gresources>

--- a/src/applets/status/settings.ui
+++ b/src/applets/status/settings.ui
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+  <requires lib="gtk+" version="3.12"/>
+  <object class="GtkAdjustment" id="adjustment1">
+    <property name="upper">20</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">10</property>
+  </object>
+  <template class="StatusSettings" parent="GtkGrid">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="hexpand">True</property>
+    <child>
+      <object class="GtkLabel" id="label1">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="halign">start</property>
+        <property name="valign">center</property>
+        <property name="hexpand">True</property>
+        <property name="label" translatable="yes">Icon Spacing</property>
+      </object>
+      <packing>
+        <property name="left_attach">0</property>
+        <property name="top_attach">0</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkSpinButton" id="spinbutton_spacing">
+        <property name="visible">True</property>
+        <property name="can_focus">True</property>
+        <property name="halign">end</property>
+        <property name="valign">center</property>
+        <property name="hexpand">True</property>
+        <property name="adjustment">adjustment1</property>
+      </object>
+      <packing>
+        <property name="left_attach">1</property>
+        <property name="top_attach">0</property>
+      </packing>
+    </child>
+  </template>
+</interface>


### PR DESCRIPTION
## Description
This PR adds a spacing setting to StatusApplet, and changes the defaults to suit the new setting. Default looks like this:

![image](https://user-images.githubusercontent.com/12981608/103845148-75054580-5069-11eb-849b-58d28d19496e.png)

### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
