### PR TITLE
Add setting to pause notifications while apps are fullscreen

### DIFF
--- a/src/panel/settings/settings_wm.vala
+++ b/src/panel/settings/settings_wm.vala
@@ -17,6 +17,7 @@ namespace Budgie {
 		private Settings budgie_wm_settings;
 		private Gtk.Switch center_windows;
 		private Gtk.Switch disable_night_light;
+		private Gtk.Switch pause_notifications;
 		private Gtk.ComboBox combo_layouts;
 		private Gtk.Switch switch_dialogs;
 		private Gtk.Switch switch_focus;
@@ -56,6 +57,12 @@ namespace Budgie {
 			grid.add_row(new SettingsRow(disable_night_light,
 				_("Disable Night Light mode when windows are fullscreen"),
 				_("Disables Night Light mode when a window is fullscreen. Re-enables when leaving fullscreen.")
+			));
+
+			pause_notifications = new Gtk.Switch();
+			grid.add_row(new SettingsRow(pause_notifications,
+				_("Pause notifications when windows are fullscreen"),
+				_("Prevents notifications from appearing when a window is fullscreen. Unpauses when leaving fullscreen.")
 			));
 
 			switch_tiling = new Gtk.Switch();
@@ -104,6 +111,7 @@ namespace Budgie {
 			budgie_wm_settings.bind("button-style", combo_layouts, "active-id", SettingsBindFlags.DEFAULT);
 			budgie_wm_settings.bind("center-windows", center_windows, "active", SettingsBindFlags.DEFAULT);
 			budgie_wm_settings.bind("disable-night-light-on-fullscreen", disable_night_light, "active", SettingsBindFlags.DEFAULT);
+			budgie_wm_settings.bind("pause-notifications-on-fullscreen", pause_notifications, "active", SettingsBindFlags.DEFAULT);
 			budgie_wm_settings.bind("edge-tiling", switch_tiling,  "active", SettingsBindFlags.DEFAULT);
 			budgie_wm_settings.bind("focus-mode", switch_focus, "active", SettingsBindFlags.DEFAULT);
 			budgie_wm_settings.bind("force-unredirect", switch_unredirect, "active", SettingsBindFlags.DEFAULT);

--- a/src/raven/raven.vala
+++ b/src/raven/raven.vala
@@ -156,6 +156,15 @@ namespace Budgie {
 			this.dnd_enabled = enable;
 			this.DoNotDisturbChanged(this.dnd_enabled);
 		}
+
+		/**
+		* Notification pausing on fullscreen functionality
+		*/
+		public signal void PauseNotificationsChanged(bool paused);
+
+		public void SetPauseNotifications(bool paused) throws DBusError, IOError {
+			PauseNotificationsChanged(paused);
+		}
 	}
 
 	public class Raven : Gtk.Window {

--- a/src/wm/com.solus-project.budgie.wm.gschema.xml
+++ b/src/wm/com.solus-project.budgie.wm.gschema.xml
@@ -68,6 +68,12 @@
 			<description>Disables Night Light mode when a window is fullscreen. Re-enables when leaving fullscreen.</description>
 		</key>
 
+		<key type="b" name="pause-notifications-on-fullscreen">
+			<default>false</default>
+			<summary>Pause notifications when windows are fullscreen</summary>
+			<description>Prevents notifications from appearing when a window is fullscreen. Unpauses when leaving fullscreen.</description>
+		</key>
+
 		<key type="b" name="experimental-enable-run-dialog-as-menu">
 			<default>false</default>
 			<summary>Enables the Budgie Run Dialog to be launched with the normal overlay key</summary>


### PR DESCRIPTION
## Description
This PR adds the ability to pause notifications (separate from the Do Not Disturb setting) while apps are fullscreen. This prevents the compositor from enabling while a video game is being played in fullscreen or windowed borderless.

Fixes #1735.

### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
