### PR TITLE
Fix issue with VirtualBox icon not being displayed in TaskList

### DIFF
--- a/src/abomination/abomination.vala
+++ b/src/abomination/abomination.vala
@@ -129,6 +129,13 @@ namespace Budgie {
 				return;
 			}
 
+			//  Basically, virtualbox opens two windows that are part of the same group, but window 1 is immediately closed,
+			//  after which window 2 is openned, resulting in window 1 icon being used, which gets removed.
+			//  Or at least it seems to be something like that...
+			if (app.name == "VirtualBox" || app.name == "VirtualBoxVM") {
+				return;
+			}
+
 			Array<AbominationRunningApp>? group_apps = this.running_apps.get(app.group);
 
 			bool no_group_yet = false;


### PR DESCRIPTION
## Description

Fixed issue where VirtualBox icon was immediately removed from TaskList. I traced down the issue to being related to the fact that VirtualBox opens two window when it start, one whose name is "VirtualBox", and then a second one called "Oracle VM VirtualBox Manager", with both window being part of the same group. The fist window close immediately, resulting in icon being created, then removed from the TaskList, and TaskList considering that the app is not open until it gets reinitialized (e.g. nohup budgie-panel --replace). To avoid the issue, I simply stopped creating an app in Abomination for the first window, resulting in added_app signal not being sent. 

At least, I think that was the issue, to be honest, I'm not too sure, brain is dead after tracing all the signals...

Should close #1427

### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
