### PR TITLE
Improve stability of CarbonTray

### DIFF
--- a/src/applets/tray/carbontray/child.c
+++ b/src/applets/tray/carbontray/child.c
@@ -18,10 +18,11 @@
 
 // static method header
 
-static void carbon_child_init(CarbonChild*);
-static void carbon_child_get_preferred_size(GtkWidget*, int*, int*);
-static bool set_wmclass(CarbonChild*, Display*);
-
+static void carbon_child_init(CarbonChild* child);
+static void carbon_child_get_preferred_size(GtkWidget* parent, int* minimumSize, int* naturalSize);
+static bool set_wmclass(CarbonChild* self, GdkDisplay* display, Display* xdisplay);
+static void synchronized_display_error_trap_push(GdkDisplay* display);
+static bool synchronized_display_error_trap_pop(GdkDisplay* display);
 
 
 // define our type with the macro
@@ -29,11 +30,10 @@ static bool set_wmclass(CarbonChild*, Display*);
 G_DEFINE_TYPE(CarbonChild, carbon_child, GTK_TYPE_SOCKET)
 
 
-
 // public method implementations
 
 CarbonChild* carbon_child_new(int size, bool shouldComposite, GdkScreen* screen, Window iconWindow) {
-	if (GDK_IS_SCREEN(screen) == FALSE) {
+	if (GDK_IS_SCREEN(screen) == false) {
 		g_warning("No screen to place tray icon onto");
 		return NULL;
 	}
@@ -46,10 +46,10 @@ CarbonChild* carbon_child_new(int size, bool shouldComposite, GdkScreen* screen,
 	GdkDisplay* display = gdk_screen_get_display(screen);
 	Display* xdisplay = GDK_DISPLAY_XDISPLAY(display);
 
-	gdk_x11_display_error_trap_push(display);
+	synchronized_display_error_trap_push(display);
 	XWindowAttributes attributes;
 	int result = XGetWindowAttributes(xdisplay, iconWindow, &attributes);
-	int error = gdk_x11_display_error_trap_pop(display);
+	int error = synchronized_display_error_trap_pop(display);
 
 	if (result == 0) {
 		g_info("Failed to populate icon window attributes for tray icon");
@@ -62,14 +62,17 @@ CarbonChild* carbon_child_new(int size, bool shouldComposite, GdkScreen* screen,
 	}
 
 	GdkVisual* visual = gdk_x11_screen_lookup_visual(screen, attributes.visual->visualid);
-	if (visual == NULL || GDK_IS_VISUAL(visual) == FALSE) {
+	if (visual == NULL || GDK_IS_VISUAL(visual) == false) {
 		return NULL;
 	}
 
 	CarbonChild* self = g_object_new(CARBON_TYPE_CHILD, NULL);
 	self->preferredSize = size;
 	self->iconWindow = iconWindow;
-	self->isComposited = FALSE;
+	self->hasAlpha = false;
+	self->parentRelativeBg = false;
+	self->wmclass = NULL;
+
 	gtk_widget_set_visual(GTK_WIDGET(self), visual);
 
 	if (shouldComposite) {
@@ -80,12 +83,11 @@ CarbonChild* carbon_child_new(int size, bool shouldComposite, GdkScreen* screen,
 		gdk_visual_get_blue_pixel_details(visual, NULL, NULL, &blue_prec);
 
 		if (red_prec + blue_prec + green_prec < gdk_visual_get_depth(visual)) {
-			self->isComposited = TRUE;
+			self->hasAlpha = true;
 		}
 	}
 
-	self->wmclass = NULL;
-	if (!set_wmclass(self, xdisplay)) {
+	if (!set_wmclass(self, display, xdisplay)) {
 		// the icon window turned sour while we were getting alpha details. ignore the child
 		return NULL;
 	}
@@ -95,34 +97,31 @@ CarbonChild* carbon_child_new(int size, bool shouldComposite, GdkScreen* screen,
 
 bool carbon_child_realize(CarbonChild* self) {
 	GtkWidget* widget = GTK_WIDGET(self);
-	GdkWindow* window = gtk_widget_get_window(widget);
+	self->widgetWindow = gtk_widget_get_window(widget);
 
 	GdkDisplay* display = gtk_widget_get_display(widget);
-	Display* xdisplay = GDK_DISPLAY_XDISPLAY(display);
 
 	// make X calls synchronous for background setting, so that BadWindow errors can be caught
-	gdk_x11_display_error_trap_push(display);
-	XSynchronize(xdisplay, true);
+	synchronized_display_error_trap_push(display);
 
-	if (self->isComposited) {
+	Display* xdisplay = GDK_DISPLAY_XDISPLAY(display);
+	if (self->hasAlpha) {
 		XSetWindowBackground(xdisplay, self->iconWindow, 0);
-	} else if (gtk_widget_get_visual(widget) == gdk_window_get_visual(gdk_window_get_parent(window))) {
+	} else if (gtk_widget_get_visual(widget) == gdk_window_get_visual(gdk_window_get_parent(self->widgetWindow))) {
 		XSetWindowBackgroundPixmap(xdisplay, self->iconWindow, None);
-	} else {
-		self->parentRelativeBg = FALSE;
+		self->parentRelativeBg = true;
 	}
 
 	// make X calls asynchronous again, all errors have already been trapped
-	XSynchronize(xdisplay, false);
-	int error = gdk_x11_display_error_trap_pop(display);
+	int error = synchronized_display_error_trap_pop(display);
 
 	if (error != 0) {
 		g_warning("Encountered X error %d when setting background for tray icon", error);
 		return false;
 	}
 
-	gdk_window_set_composited(window, self->isComposited);
-	gtk_widget_set_app_paintable(widget, self->parentRelativeBg || self->isComposited);
+	gdk_window_set_composited(self->widgetWindow, self->hasAlpha);
+	gtk_widget_set_app_paintable(widget, self->parentRelativeBg || self->hasAlpha);
 	gtk_widget_set_size_request(widget, self->preferredSize, self->preferredSize);
 	return true;
 }
@@ -143,8 +142,8 @@ void carbon_child_draw_on_tray(CarbonChild* self, GtkWidget* parent, cairo_t* cr
 		allocation.y = allocation.y - parentAllocation.y;
 	}
 	cairo_save(cr);
-	GdkWindow* window = gtk_widget_get_window(GTK_WIDGET(self));
-	gdk_cairo_set_source_window(cr, window, allocation.x, allocation.y);
+
+	gdk_cairo_set_source_window(cr, self->widgetWindow, allocation.x, allocation.y);
 	cairo_rectangle(cr, allocation.x, allocation.y, allocation.width, allocation.height);
 	cairo_clip(cr);
 	cairo_paint(cr);
@@ -174,21 +173,30 @@ static void carbon_child_class_init(CarbonChildClass* klass) {
 	widget_class->get_preferred_height = carbon_child_get_preferred_size;
 }
 
-static bool set_wmclass(CarbonChild* self, Display* xdisplay) {
+static bool set_wmclass(CarbonChild* self, GdkDisplay* display, Display* xdisplay) {
 	XClassHint ch = {0};
 
-	GdkDisplay* display = gdk_display_get_default();
-	gdk_x11_display_error_trap_push(display);
+	synchronized_display_error_trap_push(display);
 	XGetClassHint(xdisplay, self->iconWindow, &ch);
-	int error = gdk_x11_display_error_trap_pop(display);
+	int error = synchronized_display_error_trap_pop(display);
 
 	if (error != 0) {
 		g_warning("Encountered X error %d when obtaining class hint for tray icon", error);
-		return FALSE;
+		return false;
 	}
 
 	if (ch.res_name != NULL) XFree(ch.res_name);
 	if (ch.res_class != NULL) self->wmclass = ch.res_class;
 
-	return TRUE;
+	return true;
+}
+
+static void synchronized_display_error_trap_push(GdkDisplay* display) {
+	gdk_x11_display_error_trap_push(display);
+	XSynchronize(GDK_DISPLAY_XDISPLAY(display), true);
+}
+
+static bool synchronized_display_error_trap_pop(GdkDisplay* display) {
+	XSynchronize(GDK_DISPLAY_XDISPLAY(display), false);
+	return gdk_x11_display_error_trap_pop(display);
 }

--- a/src/applets/tray/carbontray/child.c
+++ b/src/applets/tray/carbontray/child.c
@@ -33,7 +33,7 @@ G_DEFINE_TYPE(CarbonChild, carbon_child, GTK_TYPE_SOCKET)
 // public method implementations
 
 CarbonChild* carbon_child_new(int size, bool shouldComposite, GdkScreen* screen, Window iconWindow) {
-	if (GDK_IS_SCREEN(screen) == false) {
+	if (!GDK_IS_SCREEN(screen)) {
 		g_warning("No screen to place tray icon onto");
 		return NULL;
 	}
@@ -62,7 +62,7 @@ CarbonChild* carbon_child_new(int size, bool shouldComposite, GdkScreen* screen,
 	}
 
 	GdkVisual* visual = gdk_x11_screen_lookup_visual(screen, attributes.visual->visualid);
-	if (visual == NULL || GDK_IS_VISUAL(visual) == false) {
+	if (visual == NULL || !GDK_IS_VISUAL(visual)) {
 		return NULL;
 	}
 

--- a/src/applets/tray/carbontray/child.h
+++ b/src/applets/tray/carbontray/child.h
@@ -22,11 +22,12 @@ typedef struct _CarbonChild {
 
 	int preferredSize;
 	Window iconWindow;
+	GdkWindow* widgetWindow;
 
 	char* wmclass;
 
 	bool parentRelativeBg;
-	bool isComposited;
+	bool hasAlpha;
 } CarbonChild;
 
 typedef struct _CarbonChildClass {
@@ -34,11 +35,9 @@ typedef struct _CarbonChildClass {
 } CarbonChildClass;
 
 
-
 #define CARBON_TYPE_CHILD (carbon_child_get_type())
 #define CARBON_CHILD(obj) (G_TYPE_CHECK_INSTANCE_CAST((obj), CARBON_TYPE_CHILD, CarbonChild))
 #define CARBON_IS_CHILD(obj) (G_TYPE_CHECK_INSTANCE_TYPE((obj), CARBON_TYPE_CHILD))
-
 
 
 GType carbon_child_get_type(void);

--- a/src/applets/tray/carbontray/tray.c
+++ b/src/applets/tray/carbontray/tray.c
@@ -137,7 +137,7 @@ bool carbon_tray_register(CarbonTray* tray, GdkScreen* screen) {
 }
 
 void carbon_tray_unregister(CarbonTray* tray) {
-	if (GTK_IS_WIDGET(tray->invisible) == false) {
+	if (!GTK_IS_WIDGET(tray->invisible)) {
 		return;
 	}
 
@@ -223,7 +223,7 @@ static GdkFilterReturn window_filter(GdkXEvent* xev, GdkEvent* event, void* user
 	XEvent* xevent = (XEvent*) xev;
 	CarbonTray* tray = (CarbonTray*) userData;
 
-	if (GTK_IS_WIDGET(tray->invisible) == false) {
+	if (!GTK_IS_WIDGET(tray->invisible)) {
 		return GDK_FILTER_CONTINUE;
 	}
 

--- a/src/applets/tray/carbontray/tray.c
+++ b/src/applets/tray/carbontray/tray.c
@@ -18,7 +18,6 @@
 #include "marshal.h"
 
 
-
 // global declarations
 
 #define TRAY_REQUEST_DOCK 0
@@ -26,7 +25,6 @@
 #define TRAY_CANCEL_MESSAGE 2
 
 static unsigned int message_sent_signal;
-
 
 
 // static method header
@@ -50,11 +48,9 @@ static void set_xproperties(CarbonTray*);
 static void draw_child(GtkWidget*, void*);
 
 
-
 // define our type with the macro
 
 G_DEFINE_TYPE(CarbonTray, carbon_tray, G_TYPE_OBJECT)
-
 
 
 // public methods
@@ -93,7 +89,7 @@ bool carbon_tray_register(CarbonTray* tray, GdkScreen* screen) {
 
 	int screen_number = XScreenNumberOfScreen(gdk_x11_screen_get_xscreen(screen));
 	char* selection_name = g_strdup_printf("_NET_SYSTEM_TRAY_S%d", screen_number);
-	tray->selectionAtom = gdk_atom_intern(selection_name, FALSE);
+	tray->selectionAtom = gdk_atom_intern(selection_name, false);
 	g_free(selection_name);
 
 	tray->invisible = GTK_WIDGET(g_object_ref(G_OBJECT(invisible)));
@@ -104,7 +100,7 @@ bool carbon_tray_register(CarbonTray* tray, GdkScreen* screen) {
 
 	unsigned int timestamp = gdk_x11_get_server_time(gtk_widget_get_window(invisible));
 	GdkDisplay* display = gdk_screen_get_display(screen);
-	bool succeed = gdk_selection_owner_set_for_display(display, gtk_widget_get_window(invisible), tray->selectionAtom, timestamp, TRUE);
+	bool succeed = gdk_selection_owner_set_for_display(display, gtk_widget_get_window(invisible), tray->selectionAtom, timestamp, true);
 
 	if (succeed) {
 		Window root_window = RootWindowOfScreen(GDK_SCREEN_XSCREEN(screen));
@@ -122,14 +118,14 @@ bool carbon_tray_register(CarbonTray* tray, GdkScreen* screen) {
 		xevent.data.l[3] = 0;
 		xevent.data.l[4] = 0;
 
-		XSendEvent(GDK_DISPLAY_XDISPLAY(display), root_window, False, StructureNotifyMask, (XEvent*) &xevent);
+		XSendEvent(GDK_DISPLAY_XDISPLAY(display), root_window, false, StructureNotifyMask, (XEvent*) &xevent);
 
 		gdk_window_add_filter(gtk_widget_get_window(invisible), window_filter, tray);
 
-		GdkAtom opcode_atom = gdk_atom_intern("_NET_SYSTEM_TRAY_OPCODE", FALSE);
+		GdkAtom opcode_atom = gdk_atom_intern("_NET_SYSTEM_TRAY_OPCODE", false);
 		tray->opcodeAtom = gdk_x11_atom_to_xatom_for_display(display, opcode_atom);
 
-		GdkAtom data_atom = gdk_atom_intern("_NET_SYSTEM_TRAY_MESSAGE_DATA", FALSE);
+		GdkAtom data_atom = gdk_atom_intern("_NET_SYSTEM_TRAY_MESSAGE_DATA", false);
 		tray->dataAtom = gdk_x11_atom_to_xatom_for_display(display, data_atom);
 	} else {
 		g_object_unref(G_OBJECT(tray->invisible));
@@ -141,7 +137,7 @@ bool carbon_tray_register(CarbonTray* tray, GdkScreen* screen) {
 }
 
 void carbon_tray_unregister(CarbonTray* tray) {
-	if (GTK_IS_WIDGET(tray->invisible) == FALSE) {
+	if (GTK_IS_WIDGET(tray->invisible) == false) {
 		return;
 	}
 
@@ -151,7 +147,7 @@ void carbon_tray_unregister(CarbonTray* tray) {
 	GdkWindow* owner = gdk_selection_owner_get_for_display(display, tray->selectionAtom);
 
 	if (owner == gtk_widget_get_window(invisible)) {
-		gdk_selection_owner_set_for_display(display, NULL, tray->selectionAtom, gdk_x11_get_server_time(invisibleWindow), TRUE);
+		gdk_selection_owner_set_for_display(display, NULL, tray->selectionAtom, gdk_x11_get_server_time(invisibleWindow), true);
 	}
 
 	gdk_window_remove_filter(invisibleWindow, window_filter, tray);
@@ -217,7 +213,7 @@ static int carbon_tray_draw(GtkWidget* widget, cairo_t* cr) {
 
 	gtk_container_foreach(GTK_CONTAINER(widget), draw_child, &data);
 
-	return TRUE;
+	return true;
 }
 
 static GdkFilterReturn window_filter(GdkXEvent* xev, GdkEvent* event, void* userData) {
@@ -227,7 +223,7 @@ static GdkFilterReturn window_filter(GdkXEvent* xev, GdkEvent* event, void* user
 	XEvent* xevent = (XEvent*) xev;
 	CarbonTray* tray = (CarbonTray*) userData;
 
-	if (GTK_IS_WIDGET(tray->invisible) == FALSE) {
+	if (GTK_IS_WIDGET(tray->invisible) == false) {
 		return GDK_FILTER_CONTINUE;
 	}
 
@@ -275,9 +271,9 @@ static void handle_dock_request(CarbonTray* tray, XClientMessageEvent* xevent) {
 
 	// networkmanager applet should be packed at the end
 	if (child->wmclass != NULL && strcmp(child->wmclass, "Nm-applet") == 0) {
-		gtk_box_pack_end(GTK_BOX(tray->box), socket, FALSE, FALSE, 0);
+		gtk_box_pack_end(GTK_BOX(tray->box), socket, false, false, 0);
 	} else {
-		gtk_box_pack_start(GTK_BOX(tray->box), socket, FALSE, FALSE, 0);
+		gtk_box_pack_start(GTK_BOX(tray->box), socket, false, false, 0);
 		gtk_box_reorder_child(GTK_BOX(tray->box), socket, 0);
 	}
 
@@ -313,7 +309,7 @@ static bool handle_undock_request(GtkSocket* socket, void* userData) {
 	g_hash_table_remove(tray->socketTable, GUINT_TO_POINTER(window));
 
 	// destroys the socket
-	return FALSE;
+	return false;
 }
 
 static void handle_message_begin(CarbonTray* tray, XClientMessageEvent* xevent) {

--- a/src/applets/tray/carbontray/tray.h
+++ b/src/applets/tray/carbontray/tray.h
@@ -57,12 +57,10 @@ typedef struct {
 } CarbonDrawData;
 
 
-
 #define CARBON_TYPE_TRAY carbon_tray_get_type()
 #define CARBON_TRAY(obj) G_TYPE_CHECK_INSTANCE_CAST((obj), CARBON_TYPE_TRAY, CarbonTray)
 #define CARBON_IS_TRAY(obj) G_TYPE_CHECK_INSTANCE_TYPE((obj), CARBON_TYPE_TRAY)
 #define CARBON_TRAY_CLASS(klass) G_TYPE_CHECK_CLASS_CAST((klass), CARBON_TYPE_TRAY, CarbonTrayClass))
-
 
 
 GType carbon_tray_get_type(void);


### PR DESCRIPTION
## Description
- Synchronize all direct X calls (resolves more panel crashing with Wine applications)
- Store GdkWindow for each child instead of fetching it every time it's needed
- Initialize all field values when creating a new child
- Standardize use of stdbool `false` and `true`
- Remove excess whitespace
- Add parameter names to static function declarations

### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
