### PR TITLE
fixed issue with user defined keybinding being overridden

### DIFF
--- a/src/wm/20_solus-project.budgie.wm.gschema.override
+++ b/src/wm/20_solus-project.budgie.wm.gschema.override
@@ -10,3 +10,7 @@ button-layout = 'appmenu:minimize,maximize,close'
 
 [org.gnome.desktop.screensaver:Budgie]
 picture-uri = 'file:///usr/share/backgrounds/budgie/default.jpg'
+
+[org.gnome.desktop.wm.keybindings:Budgie]
+switch-input-source = '[\'<Alt>Shift_L\', \'<Super>space\', \'XF86Keyboard\']'
+switch-input-source-backward = '[\'<Super><Shift>space\', \'<Shift>XF86Keyboard\']'

--- a/src/wm/com.solus-project.budgie.wm.gschema.xml
+++ b/src/wm/com.solus-project.budgie.wm.gschema.xml
@@ -122,18 +122,6 @@
 			<description>Application that is run when taking a screenshot of all displays</description>
 		</key>
 
-		<key type="as" name="switch-input-source">
-			<default><![CDATA[['<Alt>Shift_L', '<Super>space', 'XF86Keyboard']]]></default>
-			<summary>Switch to the next input source</summary>
-			<description>Switch to the next input souce</description>
-		</key>
-
-		<key type="as" name="switch-input-source-backward">
-			<default><![CDATA[['<Super><Shift>space', '<Shift>XF86Keyboard']]]></default>
-			<summary>Switch to the previous input source</summary>
-			<description>Switch to the previous input souce</description>
-		</key>
-
 		<key type="as" name="take-region-screenshot">
 			<default><![CDATA[['<Ctrl>Print']]]></default>
 			<summary>Take screenshot of selectable region</summary>

--- a/src/wm/keyboard.vala
+++ b/src/wm/keyboard.vala
@@ -121,7 +121,7 @@ namespace Budgie {
 			var display = wm.get_display();
 
 			/* Hook into GNOME defaults */
-			var schema = new Settings("com.solus-project.budgie-wm");
+			var schema = new Settings("org.gnome.desktop.wm.keybindings");
 			display.add_keybinding("switch-input-source", schema, Meta.KeyBindingFlags.NONE, switch_input_source);
 			display.add_keybinding("switch-input-source-backward", schema, Meta.KeyBindingFlags.NONE, switch_input_source_backward);
 		}


### PR DESCRIPTION
## Description

This PR fixed the issue with user defined keybinding being overridden when a keybinding is defined in `com.solus-project.budgie-wm` gschema. The problem was introduced with [f7fb331](https://github.com/solus-project/budgie-desktop/commit/f7fb33192f9bcfd5665c4f95cb9d23124ebffe7d), so I tried to solve it in a way that doesn't break those changes, but I was not able to assert it didn't break the changes made in this commit as `<Alt>Shift_L` never worked on my system to change the keyboard layout.

Resolves #2134

### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
