### PR TITLE
Customizable Clock Applet

### DIFF
--- a/src/applets/clock/ClockApplet.vala
+++ b/src/applets/clock/ClockApplet.vala
@@ -47,36 +47,6 @@ public class ClockApplet : Budgie.Applet {
 
 	public string uuid { public set; public get; }
 
-	// Make a fancy button with a direction indicator
-	Gtk.Button new_directional_button(string label_str, Gtk.PositionType arrow_direction) {
-		var box = new Gtk.Box(Gtk.Orientation.HORIZONTAL, 0);
-		box.halign = Gtk.Align.FILL;
-		var label = new Gtk.Label(label_str);
-		var button = new Gtk.Button();
-		var image = new Gtk.Image();
-
-		if (arrow_direction == Gtk.PositionType.RIGHT) {
-			image.set_from_icon_name("go-next-symbolic", Gtk.IconSize.MENU);
-			box.pack_start(label, true, true, 0);
-			box.pack_end(image, false, false, 1);
-			image.margin_start = 6;
-			label.margin_start = 6;
-		} else {
-			image.set_from_icon_name("go-previous-symbolic", Gtk.IconSize.MENU);
-			box.pack_start(image, false, false, 0);
-			box.pack_start(label, true, true, 0);
-			image.margin_end = 6;
-		}
-
-		label.halign = Gtk.Align.START;
-		label.margin = 0;
-		box.margin = 0;
-		box.border_width = 0;
-		button.get_style_context().add_class(Gtk.STYLE_CLASS_FLAT);
-		button.add(box);
-		return button;
-	}
-
 	Gtk.Button new_plain_button(string label_str) {
 		Gtk.Button ret = new Gtk.Button.with_label(label_str);
 		ret.get_child().halign = Gtk.Align.START;
@@ -140,7 +110,7 @@ public class ClockApplet : Budgie.Applet {
 		stack.get_style_context().add_class("clock-applet-stack");
 
 		popover.add(stack);
-		stack.set_homogeneous(false);
+		stack.set_homogeneous(true);
 		stack.set_transition_type(Gtk.StackTransitionType.SLIDE_LEFT_RIGHT);
 
 		var menu = new Gtk.Box(Gtk.Orientation.VERTICAL, 1);
@@ -151,44 +121,10 @@ public class ClockApplet : Budgie.Applet {
 		time_button.clicked.connect(on_date_activate);
 		cal_button.clicked.connect(on_cal_activate);
 
-		// menu page 1
 		menu.pack_start(time_button, false, false, 0);
 		menu.pack_start(cal_button, false, false, 0);
-		var sub_button = this.new_directional_button(_("Preferences"), Gtk.PositionType.RIGHT);
-		sub_button.clicked.connect(() => { stack.set_visible_child_name("prefs"); });
-		menu.pack_end(sub_button, false, false, 2);
 
-		stack.add_named(menu, "root");
-
-		// page2
-		menu = new Gtk.Box(Gtk.Orientation.VERTICAL, 1);
-		menu.border_width = 6;
-
-		var check_date = new Gtk.CheckButton.with_label(_("Show date"));
-		check_date.get_child().set_property("margin-start", 8);
-
-		var check_seconds = new Gtk.CheckButton.with_label(_("Show seconds"));
-		check_seconds.get_child().set_property("margin-start", 8);
-
-
-		var clock_format = new Gtk.CheckButton.with_label(_("Use 24 hour time"));
-		clock_format.get_child().set_property("margin-start", 8);
-
-
-		// pack page2
-		sub_button = this.new_directional_button(_("Preferences"), Gtk.PositionType.LEFT);
-		sub_button.clicked.connect(() => { stack.set_visible_child_name("root"); });
-		menu.pack_start(sub_button, false, false, 0);
-		menu.pack_start(new Gtk.Separator(Gtk.Orientation.HORIZONTAL), false, false, 2);
-		menu.pack_start(get_settings_ui(), false, false, 0);
-		stack.add_named(menu, "prefs");
-
-
-		// Always open to the root page
-		popover.closed.connect(() => {
-			stack.set_visible_child_name("root");
-		});
-
+		stack.add(menu);
 
 		widget.button_press_event.connect((e) => {
 			if (e.button != 1) {

--- a/src/applets/clock/ClockApplet.vala
+++ b/src/applets/clock/ClockApplet.vala
@@ -141,13 +141,13 @@ public class ClockApplet : Budgie.Applet {
 		
 
 		// make sure every setting is ready
-		this.update_setting("clock-show-date");
-		this.update_setting("clock-show-seconds");
-		this.update_setting("clock-use-24-hour-time");
-		this.update_setting("clock-use-custom-format");
-		this.update_setting("clock-custom-format");
-		this.update_setting("clock-use-custom-timezone");
-		this.update_setting("clock-custom-timezone");
+		this.update_setting("show-date");
+		this.update_setting("show-seconds");
+		this.update_setting("use-24-hour-time");
+		this.update_setting("use-custom-format");
+		this.update_setting("custom-format");
+		this.update_setting("use-custom-timezone");
+		this.update_setting("custom-timezone");
 
 		Timeout.add_seconds_full(Priority.LOW, 1, update_clock);
 
@@ -212,29 +212,29 @@ public class ClockApplet : Budgie.Applet {
 
 	private void update_setting(string key) {
 		switch (key) {
-			case "clock-show-date":
+			case "show-date":
 				this.clock_show_date = settings.get_boolean(key);
 				this.date_label.set_visible(this.clock_show_date);
 				break;
-			case "clock-show-seconds":
+			case "show-seconds":
 				this.clock_show_seconds = settings.get_boolean(key);
 				this.seconds_label.set_visible(this.clock_show_seconds);
 				break;
-			case "clock-use-24-hour-time":
+			case "use-24-hour-time":
 				this.clock_use_24_hour_time = settings.get_boolean(key);
 				break;
-			case "clock-use-custom-format":
+			case "use-custom-format":
 				this.clock_use_custom_format = settings.get_boolean(key);
 				this.date_label.set_visible(!this.clock_use_custom_format);
 				this.seconds_label.set_visible(!this.clock_use_custom_format);
 				break;
-			case "clock-custom-format":
+			case "custom-format":
 				this.clock_custom_format = settings.get_string(key);
 				break;
-			case "clock-use-custom-timezone":
-			case "clock-custom-timezone":
-				if (settings.get_boolean("clock-use-custom-timezone")) {
-					this.clock_timezone = new TimeZone(settings.get_string("clock-custom-timezone"));
+			case "use-custom-timezone":
+			case "custom-timezone":
+				if (settings.get_boolean("use-custom-timezone")) {
+					this.clock_timezone = new TimeZone(settings.get_string("custom-timezone"));
 				} else {
 					this.clock_timezone = new TimeZone.local();
 				}
@@ -380,13 +380,13 @@ public class ClockSettings : Gtk.Grid {
 	private Gtk.Entry? txtTimezone;
 
 	public ClockSettings(Settings? settings) {
-		settings.bind("clock-show-date", this.swShowDate, "active", SettingsBindFlags.DEFAULT);
-		settings.bind("clock-show-seconds", this.swShowSeconds, "active", SettingsBindFlags.DEFAULT);
-		settings.bind("clock-use-24-hour-time", this.swUse24HourTime, "active", SettingsBindFlags.DEFAULT);
-		settings.bind("clock-use-custom-format", this.swCustomFormat, "active", SettingsBindFlags.DEFAULT);
-		settings.bind("clock-custom-format", this.txtFormat, "text", SettingsBindFlags.DEFAULT);
-		settings.bind("clock-use-custom-timezone", this.swCustomTimezone, "active", SettingsBindFlags.DEFAULT);
-		settings.bind("clock-custom-timezone", this.txtTimezone, "text", SettingsBindFlags.DEFAULT);
+		settings.bind("show-date", this.swShowDate, "active", SettingsBindFlags.DEFAULT);
+		settings.bind("show-seconds", this.swShowSeconds, "active", SettingsBindFlags.DEFAULT);
+		settings.bind("use-24-hour-time", this.swUse24HourTime, "active", SettingsBindFlags.DEFAULT);
+		settings.bind("use-custom-format", this.swCustomFormat, "active", SettingsBindFlags.DEFAULT);
+		settings.bind("custom-format", this.txtFormat, "text", SettingsBindFlags.DEFAULT);
+		settings.bind("use-custom-timezone", this.swCustomTimezone, "active", SettingsBindFlags.DEFAULT);
+		settings.bind("custom-timezone", this.txtTimezone, "text", SettingsBindFlags.DEFAULT);
 
 		this.swCustomFormat.notify["active"].connect(this.updateSensitve);
 		this.swCustomTimezone.notify["active"].connect(this.updateSensitve);

--- a/src/applets/clock/ClockApplet.vala
+++ b/src/applets/clock/ClockApplet.vala
@@ -212,42 +212,42 @@ public class ClockApplet : Budgie.Applet {
 	}
 
 	private void update_setting(string schema, string key) {
-		switch (schema) {
-			case CLOCK_SETTINGS_SCHEMA:
-				switch (key) {
-					case "show-date":
-						this.clock_show_date = settings.get_boolean(key);
-						this.date_label.set_visible(this.clock_show_date);
-						break;
-					case "show-seconds":
-						this.clock_show_seconds = settings.get_boolean(key);
-						this.seconds_label.set_visible(this.clock_show_seconds);
-						break;
-					case "use-custom-format":
-						this.clock_use_custom_format = settings.get_boolean(key);
-						this.date_label.set_visible(!this.clock_use_custom_format);
-						this.seconds_label.set_visible(!this.clock_use_custom_format);
-						break;
-					case "custom-format":
-						this.clock_custom_format = settings.get_string(key);
-						break;
-					case "use-custom-timezone":
-					case "custom-timezone":
-						if (settings.get_boolean("use-custom-timezone")) {
-							this.clock_timezone = new TimeZone(settings.get_string("custom-timezone"));
-						} else {
-							this.clock_timezone = new TimeZone.local();
-						}
-						break;
-				}
-				break;
-			case GNOME_SETTINGS_SCHEMA:
-				switch (key) {
-					case "clock-format": // gnome-settings
-						this.clock_use_24_hour_time = (gnome_settings.get_string("clock-format") == "24h");
-						break;
-				}
-				break;
+		if (schema == CLOCK_SETTINGS_SCHEMA) {
+			switch (key) {
+				case "show-date":
+					this.clock_show_date = settings.get_boolean(key);
+					this.date_label.set_visible(this.clock_show_date);
+					break;
+				case "show-seconds":
+					this.clock_show_seconds = settings.get_boolean(key);
+					this.seconds_label.set_visible(this.clock_show_seconds);
+					break;
+				case "use-custom-format":
+					this.clock_use_custom_format = settings.get_boolean(key);
+					this.date_label.set_visible(!this.clock_use_custom_format);
+					this.seconds_label.set_visible(!this.clock_use_custom_format);
+					break;
+				case "custom-format":
+					this.clock_custom_format = settings.get_string(key);
+					break;
+				case "use-custom-timezone":
+				case "custom-timezone":
+					if (settings.get_boolean("use-custom-timezone")) {
+						this.clock_timezone = new TimeZone(settings.get_string("custom-timezone"));
+					} else {
+						this.clock_timezone = new TimeZone.local();
+					}
+					break;
+			}
+			return;
+		}
+		if (schema == GNOME_SETTINGS_SCHEMA) {
+			switch (key) {
+				case "clock-format": // gnome-settings
+					this.clock_use_24_hour_time = (gnome_settings.get_string("clock-format") == "24h");
+					break;
+			}
+			return;
 		}
 	}
 
@@ -307,16 +307,10 @@ public class ClockApplet : Budgie.Applet {
 		
 		string format;
 		if (!this.clock_use_custom_format) {
-			if (!this.clock_use_24_hour_time) {
-				format = "%l:%M";
-			} else {
-				format = "%H:%M";
-			}
+			format = (this.clock_use_24_hour_time) ? "%H:%M" : "%l:%M";
 
-			if (orient == Gtk.Orientation.HORIZONTAL) {
-				if (this.clock_show_seconds) {
-					format += ":%S";
-				}
+			if (orient == Gtk.Orientation.HORIZONTAL && this.clock_show_seconds) {
+				format += ":%S";
 			}
 
 			if (!this.clock_use_24_hour_time) {

--- a/src/applets/clock/ClockApplet.vala
+++ b/src/applets/clock/ClockApplet.vala
@@ -349,49 +349,49 @@ public class ClockApplet : Budgie.Applet {
 public class ClockSettings : Gtk.Grid {
 
 	[GtkChild]
-	private Gtk.Switch? swShowDate;
+	private Gtk.Switch? show_date;
 
 	[GtkChild]
-	private Gtk.Switch? swShowSeconds;
+	private Gtk.Switch? show_seconds;
 
 	[GtkChild]
-	private Gtk.Switch? swUse24HourTime;
+	private Gtk.Switch? use_24_hour_time;
 
 	[GtkChild]
-	private Gtk.Switch? swCustomFormat;
+	private Gtk.Switch? use_custom_format;
 
 	[GtkChild]
-	private Gtk.Entry? txtFormat;
+	private Gtk.Entry? custom_format;
 	
 	[GtkChild]
-	private Gtk.Switch? swCustomTimezone;
+	private Gtk.Switch? use_custom_timezone;
 
 	[GtkChild]
-	private Gtk.Entry? txtTimezone;
+	private Gtk.Entry? custom_timezone;
 
 	public ClockSettings(Settings? settings) {
-		settings.bind("show-date", this.swShowDate, "active", SettingsBindFlags.DEFAULT);
-		settings.bind("show-seconds", this.swShowSeconds, "active", SettingsBindFlags.DEFAULT);
-		settings.bind("use-24-hour-time", this.swUse24HourTime, "active", SettingsBindFlags.DEFAULT);
-		settings.bind("use-custom-format", this.swCustomFormat, "active", SettingsBindFlags.DEFAULT);
-		settings.bind("custom-format", this.txtFormat, "text", SettingsBindFlags.DEFAULT);
-		settings.bind("use-custom-timezone", this.swCustomTimezone, "active", SettingsBindFlags.DEFAULT);
-		settings.bind("custom-timezone", this.txtTimezone, "text", SettingsBindFlags.DEFAULT);
+		settings.bind("show-date", this.show_date, "active", SettingsBindFlags.DEFAULT);
+		settings.bind("show-seconds", this.show_seconds, "active", SettingsBindFlags.DEFAULT);
+		settings.bind("use-24-hour-time", this.use_24_hour_time, "active", SettingsBindFlags.DEFAULT);
+		settings.bind("use-custom-format", this.use_custom_format, "active", SettingsBindFlags.DEFAULT);
+		settings.bind("custom-format", this.custom_format, "text", SettingsBindFlags.DEFAULT);
+		settings.bind("use-custom-timezone", this.use_custom_timezone, "active", SettingsBindFlags.DEFAULT);
+		settings.bind("custom-timezone", this.custom_timezone, "text", SettingsBindFlags.DEFAULT);
 
-		this.swCustomFormat.notify["active"].connect(this.updateSensitve);
-		this.swCustomTimezone.notify["active"].connect(this.updateSensitve);
+		this.use_custom_format.notify["active"].connect(this.updateSensitve);
+		this.use_custom_timezone.notify["active"].connect(this.updateSensitve);
 
 		this.updateSensitve();
 	}
 
 	private void updateSensitve() {
-		var useCustomFormat = this.swCustomFormat.get_active();
-		this.swShowDate.set_sensitive(!useCustomFormat);
-		this.swShowSeconds.set_sensitive(!useCustomFormat);
-		this.swUse24HourTime.set_sensitive(!useCustomFormat);
-		this.txtFormat.set_sensitive(useCustomFormat);
+		var useCustomFormat = this.use_custom_format.get_active();
+		this.show_date.set_sensitive(!useCustomFormat);
+		this.show_seconds.set_sensitive(!useCustomFormat);
+		this.use_24_hour_time.set_sensitive(!useCustomFormat);
+		this.custom_format.set_sensitive(useCustomFormat);
 
-		this.txtTimezone.set_sensitive(this.swCustomTimezone.get_active());
+		this.custom_timezone.set_sensitive(this.use_custom_timezone.get_active());
 	}
 
 }

--- a/src/applets/clock/ClockApplet.vala
+++ b/src/applets/clock/ClockApplet.vala
@@ -24,7 +24,6 @@ public class ClockApplet : Budgie.Applet {
 	protected Gtk.Label date_label;
 	protected Gtk.Label seconds_label;
 
-
 	private DateTime time;
 
 	protected Settings settings;
@@ -36,7 +35,6 @@ public class ClockApplet : Budgie.Applet {
 	Gtk.Orientation orient = Gtk.Orientation.HORIZONTAL;
 
 	private unowned Budgie.PopoverManager? manager = null;
-
 
 	private bool clock_show_date;
 	private bool clock_show_seconds;
@@ -51,7 +49,6 @@ public class ClockApplet : Budgie.Applet {
 		Gtk.Button ret = new Gtk.Button.with_label(label_str);
 		ret.get_child().halign = Gtk.Align.START;
 		ret.get_style_context().add_class(Gtk.STYLE_CLASS_FLAT);
-
 		return ret;
 	}
 
@@ -73,13 +70,11 @@ public class ClockApplet : Budgie.Applet {
 		settings_schema = "com.solus-project.clock";
 		settings_prefix = "/com/solus-project/clock/instance/clock";
 
-
 		this.settings = this.get_applet_settings(uuid);
 
 		widget = new Gtk.EventBox();
 		layout = new Gtk.Box(Gtk.Orientation.HORIZONTAL, 2);
 		widget.add(layout);
-
 
 		clock_label = new Gtk.Label("");
 		layout.pack_start(clock_label, false, false, 0);
@@ -138,8 +133,6 @@ public class ClockApplet : Budgie.Applet {
 			return Gdk.EVENT_STOP;
 		});
 
-		
-
 		// make sure every setting is ready
 		this.update_setting("show-date");
 		this.update_setting("show-seconds");
@@ -162,15 +155,12 @@ public class ClockApplet : Budgie.Applet {
 		cal_button.clicked.connect(on_cal_activate);
 
 		update_cal();
-
 		
 		add(widget);
-
 
 		popover.get_child().show_all();
 
 		show_all();
-
 	}
 
 	void update_cal() {

--- a/src/applets/clock/com.solus-project.clock.gschema.xml
+++ b/src/applets/clock/com.solus-project.clock.gschema.xml
@@ -11,11 +11,6 @@
       <summary>Show seconds</summary>
       <description>Whether to show seconds in the clock.</description>
     </key>
-    <key type="b" name="use-24-hour-time">
-      <default>false</default>
-      <summary>Use 24 hour time</summary>
-      <description>Whether to use the 24 hour time format.</description>
-    </key>
     <key type="b" name="use-custom-format">
       <default>false</default>
       <summary>Use custom format</summary>

--- a/src/applets/clock/com.solus-project.clock.gschema.xml
+++ b/src/applets/clock/com.solus-project.clock.gschema.xml
@@ -1,37 +1,37 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schemalist gettext-domain="budgie">
 <schema id="com.solus-project.clock">
-    <key type="b" name="clock-show-date">
+    <key type="b" name="show-date">
       <default>false</default>
       <summary>Show seconds</summary>
       <description>Whether to show the date.</description>
     </key>
-    <key type="b" name="clock-show-seconds">
+    <key type="b" name="show-seconds">
       <default>false</default>
       <summary>Show seconds</summary>
       <description>Whether to show seconds in the clock.</description>
     </key>
-    <key type="b" name="clock-use-24-hour-time">
+    <key type="b" name="use-24-hour-time">
       <default>false</default>
       <summary>Use 24 hour time</summary>
       <description>Whether to use the 24 hour time format.</description>
     </key>
-    <key type="b" name="clock-use-custom-format">
+    <key type="b" name="use-custom-format">
       <default>false</default>
       <summary>Use custom format</summary>
       <description>Whether to use a custom format for the clock.</description>
     </key>
-    <key type="s" name="clock-custom-format">
+    <key type="s" name="custom-format">
       <default>"%H:%M:%S %d.%m.%Y"</default>
       <summary>Format</summary>
       <description>Format of the clock</description>
     </key>
-    <key type="b" name="clock-use-custom-timezone">
+    <key type="b" name="use-custom-timezone">
       <default>false</default>
       <summary>Use custom timezone</summary>
       <description>Whether to use a custom timezone instead of the system one.</description>
     </key>
-    <key type="s" name="clock-custom-timezone">
+    <key type="s" name="custom-timezone">
       <default>"UTC"</default>
       <summary>Timezone</summary>
       <description>Timezone of the clock, leave empty for system default.</description>

--- a/src/applets/clock/com.solus-project.clock.gschema.xml
+++ b/src/applets/clock/com.solus-project.clock.gschema.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schemalist gettext-domain="budgie">
+<schema id="com.solus-project.clock">
+    <key type="b" name="clock-show-date">
+      <default>false</default>
+      <summary>Show seconds</summary>
+      <description>Whether to show the date.</description>
+    </key>
+    <key type="b" name="clock-show-seconds">
+      <default>false</default>
+      <summary>Show seconds</summary>
+      <description>Whether to show seconds in the clock.</description>
+    </key>
+    <key type="b" name="clock-use-24-hour-time">
+      <default>false</default>
+      <summary>Use 24 hour time</summary>
+      <description>Whether to use the 24 hour time format.</description>
+    </key>
+    <key type="b" name="clock-use-custom-format">
+      <default>false</default>
+      <summary>Use custom format</summary>
+      <description>Whether to use a custom format for the clock.</description>
+    </key>
+    <key type="s" name="clock-custom-format">
+      <default>"%H:%M:%S %d.%m.%Y"</default>
+      <summary>Format</summary>
+      <description>Format of the clock</description>
+    </key>
+    <key type="b" name="clock-use-custom-timezone">
+      <default>false</default>
+      <summary>Use custom timezone</summary>
+      <description>Whether to use a custom timezone instead of the system one.</description>
+    </key>
+    <key type="s" name="clock-custom-timezone">
+      <default>"UTC"</default>
+      <summary>Timezone</summary>
+      <description>Timezone of the clock, leave empty for system default.</description>
+    </key>
+  </schema>
+</schemalist>

--- a/src/applets/clock/meson.build
+++ b/src/applets/clock/meson.build
@@ -1,5 +1,7 @@
 # Clock Applet build
 
+gnome = import('gnome')
+
 applet_clock_dir = applets_dir + '.clock'
 
 custom_target('plugin-file-clock',
@@ -9,26 +11,45 @@ custom_target('plugin-file-clock',
     install : true,
     install_dir : applet_clock_dir)
 
+gresource = join_paths(meson.current_source_dir(), 'plugin.gresource.xml')
+
+# Compile the assets into the binary
+applet_clock_resources = gnome.compile_resources(
+    'clock-applet-resources',
+    gresource,
+    source_dir: meson.current_source_dir(),
+    c_name: 'budgie_Clock',
+)
+
 applet_clock_sources = [
     'ClockApplet.vala',
+    applet_clock_resources,
 ]
 
-applet_clock_deps = [
-    libplugin_vapi,
-    dep_gtk3,
-    dep_peas,
-    link_libplugin,
-]
 
 shared_library(
     'clockapplet',
     applet_clock_sources,
-    dependencies: applet_clock_deps,
+    dependencies: [
+        libplugin_vapi,
+        dep_gtk3,
+        dep_peas,
+        link_libplugin,
+    ],
     vala_args: [
-        '--pkg', 'libpeas-1.0',
-        '--pkg', 'gio-unix-2.0',
         '--pkg', 'gtk+-3.0',
+        '--pkg', 'glib-2.0',
+        '--pkg', 'gio-unix-2.0',
+        '--pkg', 'libpeas-1.0',
+        # Make gresource work
+        '--target-glib=2.38',
+        '--gresources=' + gresource,
     ],
     install: true,
     install_dir: applet_clock_dir,
+)
+
+install_data(
+    'com.solus-project.clock.gschema.xml',
+    install_dir: join_paths(datadir, 'glib-2.0', 'schemas'),
 )

--- a/src/applets/clock/plugin.gresource.xml
+++ b/src/applets/clock/plugin.gresource.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gresources>
+        <gresource prefix="/com/solus-project/clock">
+                <file preprocess="xml-stripblanks">settings.ui</file>
+        </gresource>
+</gresources>

--- a/src/applets/clock/settings.ui
+++ b/src/applets/clock/settings.ui
@@ -1,0 +1,152 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.22.2 -->
+<interface>
+  <requires lib="gtk+" version="3.12"/>
+  <template class="ClockSettings" parent="GtkGrid">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="row_spacing">4</property>
+    <property name="column_spacing">4</property>
+    <child>
+      <object class="GtkLabel">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="halign">start</property>
+        <property name="label" translatable="yes">Show date</property>
+      </object>
+      <packing>
+        <property name="left_attach">0</property>
+        <property name="top_attach">0</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkSwitch" id="swShowDate">
+        <property name="visible">True</property>
+        <property name="can_focus">True</property>
+        <property name="halign">end</property>
+      </object>
+      <packing>
+        <property name="left_attach">1</property>
+        <property name="top_attach">0</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkLabel">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="halign">start</property>
+        <property name="label" translatable="yes">Show seconds</property>
+      </object>
+      <packing>
+        <property name="left_attach">0</property>
+        <property name="top_attach">1</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkSwitch" id="swShowSeconds">
+        <property name="visible">True</property>
+        <property name="can_focus">True</property>
+        <property name="halign">end</property>
+      </object>
+      <packing>
+        <property name="left_attach">1</property>
+        <property name="top_attach">1</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkLabel">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="halign">start</property>
+        <property name="label" translatable="yes">Use 24 hour time</property>
+      </object>
+      <packing>
+        <property name="left_attach">0</property>
+        <property name="top_attach">2</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkSwitch" id="swUse24HourTime">
+        <property name="visible">True</property>
+        <property name="can_focus">True</property>
+        <property name="halign">end</property>
+      </object>
+      <packing>
+        <property name="left_attach">1</property>
+        <property name="top_attach">2</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkLabel">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="halign">start</property>
+        <property name="label" translatable="yes">Custom Format</property>
+      </object>
+      <packing>
+        <property name="left_attach">0</property>
+        <property name="top_attach">3</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkSwitch" id="swCustomFormat">
+        <property name="visible">True</property>
+        <property name="can_focus">True</property>
+        <property name="halign">end</property>
+      </object>
+      <packing>
+        <property name="left_attach">1</property>
+        <property name="top_attach">3</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkEntry" id="txtFormat">
+        <property name="visible">True</property>
+        <property name="can_focus">True</property>
+        <property name="hexpand">True</property>
+        <property name="placeholder_text" translatable="yes">%H:%M:%S %d.%m.%Y</property>
+      </object>
+      <packing>
+        <property name="left_attach">0</property>
+        <property name="top_attach">4</property>
+        <property name="width">2</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkLabel">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="halign">start</property>
+        <property name="label" translatable="yes">Custom Timezone</property>
+      </object>
+      <packing>
+        <property name="left_attach">0</property>
+        <property name="top_attach">5</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkSwitch" id="swCustomTimezone">
+        <property name="visible">True</property>
+        <property name="can_focus">True</property>
+        <property name="halign">end</property>
+      </object>
+      <packing>
+        <property name="left_attach">1</property>
+        <property name="top_attach">5</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkEntry" id="txtTimezone">
+        <property name="visible">True</property>
+        <property name="can_focus">True</property>
+        <property name="hexpand">True</property>
+        <property name="placeholder_text" translatable="yes">UTC</property>
+      </object>
+      <packing>
+        <property name="left_attach">0</property>
+        <property name="top_attach">6</property>
+        <property name="width">2</property>
+      </packing>
+    </child>
+  </template>
+</interface>

--- a/src/applets/clock/settings.ui
+++ b/src/applets/clock/settings.ui
@@ -20,7 +20,7 @@
       </packing>
     </child>
     <child>
-      <object class="GtkSwitch" id="swShowDate">
+      <object class="GtkSwitch" id="show_date">
         <property name="visible">True</property>
         <property name="can_focus">True</property>
         <property name="halign">end</property>
@@ -43,7 +43,7 @@
       </packing>
     </child>
     <child>
-      <object class="GtkSwitch" id="swShowSeconds">
+      <object class="GtkSwitch" id="show_seconds">
         <property name="visible">True</property>
         <property name="can_focus">True</property>
         <property name="halign">end</property>
@@ -66,7 +66,7 @@
       </packing>
     </child>
     <child>
-      <object class="GtkSwitch" id="swUse24HourTime">
+      <object class="GtkSwitch" id="use_24_hour_time">
         <property name="visible">True</property>
         <property name="can_focus">True</property>
         <property name="halign">end</property>
@@ -89,7 +89,7 @@
       </packing>
     </child>
     <child>
-      <object class="GtkSwitch" id="swCustomFormat">
+      <object class="GtkSwitch" id="use_custom_format">
         <property name="visible">True</property>
         <property name="can_focus">True</property>
         <property name="halign">end</property>
@@ -100,7 +100,7 @@
       </packing>
     </child>
     <child>
-      <object class="GtkEntry" id="txtFormat">
+      <object class="GtkEntry" id="custom_format">
         <property name="visible">True</property>
         <property name="can_focus">True</property>
         <property name="hexpand">True</property>
@@ -125,7 +125,7 @@
       </packing>
     </child>
     <child>
-      <object class="GtkSwitch" id="swCustomTimezone">
+      <object class="GtkSwitch" id="use_custom_timezone">
         <property name="visible">True</property>
         <property name="can_focus">True</property>
         <property name="halign">end</property>
@@ -136,7 +136,7 @@
       </packing>
     </child>
     <child>
-      <object class="GtkEntry" id="txtTimezone">
+      <object class="GtkEntry" id="custom_timezone">
         <property name="visible">True</property>
         <property name="can_focus">True</property>
         <property name="hexpand">True</property>


### PR DESCRIPTION
## Description
This pull request adds more customization to the clock applet.

Features of the updated clock applet:
* Settings are stored individual per clock applet (this means you can use multiple clock applets with different settings)
* Select a custom clock format (using the strftime format)
* Select a custom timezone


## Some Visuals
![Screenshot from 2021-06-14 20-47-05](https://user-images.githubusercontent.com/796084/121943546-fc11c480-cd51-11eb-80bb-6fb193be19d3.png)

![Screenshot from 2021-06-14 20-53-25](https://user-images.githubusercontent.com/796084/121944209-b0abe600-cd52-11eb-9b16-93f9f80da2ac.png)



### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
