### PR TITLE
Make sure we set the class group when opening windows

### DIFF
--- a/src/applets/icon-tasklist/IconTasklistApplet.vala
+++ b/src/applets/icon-tasklist/IconTasklistApplet.vala
@@ -482,6 +482,11 @@ public class IconTasklistApplet : Budgie.Applet {
 		if (grouping) {
 			if (button == null) {
 				on_class_group_opened(app.group);
+			} else {
+				// Some apps (Google Chrome) don't have their wnck groups set as expected,
+				// causing the windows to not group correctly when using the profile selection
+				// screen.
+				button.set_class_group(app.window.get_class_group());
 			}
 			return;
 		}
@@ -514,10 +519,12 @@ public class IconTasklistApplet : Budgie.Applet {
 		string? app_id = id_map.get("%lu".printf(win_id));
 		app_id = (app_id == null) ? "%lu".printf(win_id) : app_id;
 		IconButton? button = buttons.get(app_id);
-		if (button != null) {
+
+		if (button != null) { // Window was not part of a group
+			// Since this was not in a group, unset the window and update the button.
 			button.set_wnck_window(null);
 			button.update();
-		} else {
+		} else { // Window was in a group; split the group name and id
 			app_id = app_id.split("|")[0];
 			button = buttons.get(app_id);
 		}


### PR DESCRIPTION
## Description
This fixes some apps (such as Google Chrome) not being grouped correctly under certain conditions. In the case of Chrome, this happens when using multiple profiles, so the browser starts with a profile switcher window instead of a browser window.

Without this patch, the Chrome window class group is `null`. So, when grouping is enabled, set the class group to make sure this doesn't happen.

I kept in my testing comments in the lower if/else block because there is no real indication as to what is actually happening there. I thought it might be a benefit to someone else down the road.

See https://discuss.getsol.us/d/7112-google-chrome-not-highlighted-in-panel-if-running

This doesn't appear to break anything else in my testing, but a wider range of programs and test cases might be a good idea. I tested with Chrome, opening multiple Nautilus windows, and multiple LibreOffice Writer windows. Everything groups and displays as expected.

### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
