### PR TITLE
Enable Mod3 (Meta or Hyper) for Tab Switching

### DIFF
--- a/src/daemon/tabswitcher.vala
+++ b/src/daemon/tabswitcher.vala
@@ -306,7 +306,7 @@ namespace Budgie {
 			mod_timeout = 0;
 			Gdk.ModifierType modifier;
 			Gdk.Display.get_default().get_default_seat().get_pointer().get_state(Gdk.get_default_root_window(), null, out modifier);
-			if ((modifier & Gdk.ModifierType.MOD1_MASK) == 0 && (modifier & Gdk.ModifierType.MOD4_MASK) == 0 && (modifier & Gdk.ModifierType.CONTROL_MASK) == 0) {
+			if ((modifier & Gdk.ModifierType.MOD1_MASK) == 0 && (modifier & Gdk.ModifierType.MOD3_MASK) == 0 && (modifier & Gdk.ModifierType.MOD4_MASK) == 0 && (modifier & Gdk.ModifierType.CONTROL_MASK) == 0) {
 				switcher_window.hide();
 				return false;
 			}


### PR DESCRIPTION
## Description
Allows the, apparently or often, unused Mod3 in xkb/xmodmap to have Alt+Tab switcher functionality. The user does need to apply an xmodmap modification to apply either Meta or Hyper to the Mod3 group, while also removing it from either Mod2 (Alt) or Mod4 (Super) groupings.

I've not yet tested this modification but I strongly suspect it'll work the same way as the other mod mask variables do. I have also confirmed that Meta is indeed a mapable modifier in the keyboard GUI interface for the tab switcher.


### Submitter Checklist

- [ ] Squashed commits with `git rebase -i` (if needed)
- [ ] Built budgie-desktop and verified that the patch worked (if needed)
